### PR TITLE
Fix PaX ASLR check

### DIFF
--- a/checksec
+++ b/checksec
@@ -170,7 +170,7 @@ aslrcheck() {
   fi
 
   if grep -q 'PaX:' /proc/1/status 2> /dev/null; then
-    if grep -q 'PaX:' /proc/1/status 2> /dev/null | grep -q 'R'; then
+    if grep 'PaX:' /proc/1/status 2> /dev/null | grep -q 'R'; then
       echo_message '\033[32mPaX ASLR enabled\033[m\n\n' '' '' ''
     else
       echo_message '\033[31mPaX ASLR disabled\033[m\n\n' '' '' ''


### PR DESCRIPTION
`grep -q 2>/dev/null` produces no output, therefore the subsequent `grep` can't match anything and returns nonzero, which causes the `else` path to be taken unconditionally.

Found while test-driving a kernel built from a '2021 grsecurity patch published on the open Internet under the GPLv2.