### PR TITLE
fix:fix crash when os.Stat err(j is a symbolic link,but the file not exist)

### DIFF
--- a/pkg/utils/files.go
+++ b/pkg/utils/files.go
@@ -90,6 +90,9 @@ func GetAllFilesFromDir(dirName string, recursive bool) []string {
 		fileList, _ = filepath.Glob(fmt.Sprintf("%s/*", dirName))
 		for _, j := range fileList {
 			dirInfo, _ := os.Stat(j)
+			if dirInfo == nil {
+				continue
+			}
 			if j != "." && !dirInfo.IsDir() && CheckIfElf(j) {
 				results = append(results, j)
 			}


### PR DESCRIPTION
crash condition:
ln -s /bin/filenotexist /bin/symbollink
checksec dir /bin