### PR TITLE
checksec_automator.sh: Assorted cleanups

### DIFF
--- a/checksec_automator.sh
+++ b/checksec_automator.sh
@@ -2,30 +2,22 @@
 
 # keep checksec executable and checksec_automation file in same directory.
 
-#sudo find $1 -type f -executable -exec file -i '{}' \; | grep 'x-executable; charset=binary' | cut -c1- | cut -d ':' -f1 > linux_executables.txt
-
-#tree -fi $1 > linux_executables.txt
-
-help() {
-  echo "Usage: ./checksec_automation.sh [<dir_to_scan>] [<output_file_name>]"
-}
-
-#run help if nothing is passed
-if [[ "$#" -lt 1 ]]; then
-  help
+if [ ! -x checksec ]; then
+  echo 'checksec file not found or not executable - put it in the same directory and run the script again'
   exit 1
 fi
 
-find "$1" -type f -executable -exec file -i '{}' \; | grep -e 'application/x-sharedlib; charset=binary' -e 'application/x-pie-executable; charset=binary' -e 'application/x-executable; charset=binary' | cut -c1- | cut -d ':' -f1 > linux_executables.txt
+# print a help message if nothing is passed
+if [ "$#" -ne 2 ]; then
+  echo "Usage: $0 DIRECTORY_TO_SCAN OUTPUT_FILE"
+  exit 1
+fi
 
 echo "Checksec Output" | tee "$2"
 
+find "$1" -type f -executable -print0 | xargs -r0 file -i -- | grep -e 'application/x-sharedlib; charset=binary' -e 'application/x-pie-executable; charset=binary' -e 'application/x-executable; charset=binary' | cut -d: -f1 | sort |
 while read -r i; do
-  ./checksec &> /dev/null
-  if [ "$?" -eq 127 ]; then
-    echo "File not Found. Keep checksec in same directory and run the script again."
-    exit 1
-  else
-    ./checksec --file="$i" | tee -a "$2"
-  fi
-done < <(cat linux_executables.txt)
+  ./checksec --file="$i"
+done | tee -a "$2"
+
+echo 'Use "less -R" to view the output file'


### PR DESCRIPTION
- Check for checksec before the loop, not in the loop
- Use "test -x" for the above
- Check for correct and exact number of expected arguments
- Harden the find/file step by usage of -print0, xargs -r0, and -- (hardening further steps is also possible, but trickier, so not done)
- Get rid of the temporary file (use a pipe)
- Run "tee -a" outside of the loop, not per file