### PR TITLE
pkg/utils/files.go: parse all directories

### DIFF
--- a/pkg/utils/files.go
+++ b/pkg/utils/files.go
@@ -78,7 +78,7 @@ func GetAllFilesFromDir(dirName string, recursive bool) []string {
 	if recursive {
 		filepath.WalkDir(dirName, func(path string, file fs.DirEntry, err error) error {
 			if err != nil {
-				return err
+				return fs.SkipDir
 			}
 			if !file.IsDir() && CheckIfElf(path) && file.Type().IsRegular() {
 				results = append(results, path)


### PR DESCRIPTION
As stated in https://pkg.go.dev/io/fs#WalkDirFunc, if `WalkDir` function returns a non-nil error, `WalkDir` stops entirely and returns that error. As a result, if checksec is run to scan recursively a repository containing /bin, /forbidden, /usr and /forbidden is a repository set with 000 permission rights, checksec will return partial results (only /bin will be scanned). To avoid this issue, return `fs.SkipDir` instead of `err`.