### PR TITLE
Handle binaries with no sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ Using with Cross-compiled Systems
 The checksec tool can be used against cross-compiled target file-systems offline.  Key limitations to note:
 * Kernel tests - require you to execute the script on the running system you'd like to check as they directly access kernel resources to identify system configuration/state. You can specify the config file for the kernel after the -k option.
 
-* File check -  the offline testing works for all the checks but the Fortify feature.  Fortify, uses the running system's libraries vs those in the offline file-system. There are ways to workaround this (chroot) but at the moment, the ideal configuration would have this script executing on the running system when checking the files.
+* File check -  the offline testing works for all the checks but the Fortify feature.  By default, Fortify, uses the running system's libraries vs those in the offline file-system. There are ways to workaround this (chroot) but at the moment, the ideal configuration would have this script executing on the running system when checking the files. An other option is to specify where the cross-compiled libc is located through the -libc option.
 
 The checksec tool's normal use case is for runtime checking of the systems configuration.  If the system is an embedded target, the native binutils tools like readelf may not be present.  This would restrict which parts of the script will work.
 

--- a/cmd/dir.go
+++ b/cmd/dir.go
@@ -18,7 +18,7 @@ var dirCmd = &cobra.Command{
 		var Elements []interface{}
 		var ElementColors []interface{}
 		for _, file := range utils.GetAllFilesFromDir(dir, recursive) {
-			data, color := utils.RunFileChecks(file)
+			data, color := utils.RunFileChecks(file, libc)
 			Elements = append(Elements, data...)
 			ElementColors = append(ElementColors, color...)
 		}

--- a/cmd/file.go
+++ b/cmd/file.go
@@ -15,7 +15,7 @@ var fileCmd = &cobra.Command{
 		file := args[0]
 
 		utils.CheckElfExists(file)
-		data, color := utils.RunFileChecks(file)
+		data, color := utils.RunFileChecks(file, libc)
 		utils.FilePrinter(outputFormat, data, color)
 	},
 }

--- a/cmd/fortifyFile.go
+++ b/cmd/fortifyFile.go
@@ -23,7 +23,7 @@ var fortifyFileCmd = &cobra.Command{
 
 		utils.CheckElfExists(file)
 		binary := utils.GetBinary(file)
-		fortify := checksec.Fortify(file, binary)
+		fortify := checksec.Fortify(file, binary, libc)
 		output := []interface{}{
 			map[string]interface{}{
 				"name": file,

--- a/cmd/fortifyProc.go
+++ b/cmd/fortifyProc.go
@@ -30,7 +30,7 @@ var fortifyProcCmd = &cobra.Command{
 
 		utils.CheckElfExists(file)
 		binary := utils.GetBinary(file)
-		fortify := checksec.Fortify(file, binary)
+		fortify := checksec.Fortify(file, binary, libc)
 		output := []interface{}{
 			map[string]interface{}{
 				"name": file,

--- a/cmd/proc.go
+++ b/cmd/proc.go
@@ -26,7 +26,7 @@ var procCmd = &cobra.Command{
 		}
 
 		utils.CheckElfExists(file)
-		data, color := utils.RunFileChecks(file)
+		data, color := utils.RunFileChecks(file, libc)
 		utils.FilePrinter(outputFormat, data, color)
 	},
 }

--- a/cmd/procAll.go
+++ b/cmd/procAll.go
@@ -33,7 +33,7 @@ var procAllCmd = &cobra.Command{
 			if err != nil {
 				continue
 			}
-			data, color := utils.RunFileChecks(file)
+			data, color := utils.RunFileChecks(file, libc)
 			Elements = append(Elements, data...)
 			ElementColors = append(ElementColors, color...)
 		}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,6 +8,7 @@ import (
 )
 
 var (
+	libc string
 	outputFormat string
 )
 
@@ -26,6 +27,7 @@ func SetVersionInfo(version, commit, date string) {
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
 	rootCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", "table", "Output format (table, xml, json or yaml)")
+	rootCmd.PersistentFlags().StringVarP(&libc, "libc", "l", "", "Set libc location (useful for FORTIFY check on offline embedded file-system)")
 	err := rootCmd.Execute()
 	if err != nil {
 		os.Exit(1)

--- a/pkg/checksec/relro.go
+++ b/pkg/checksec/relro.go
@@ -30,7 +30,13 @@ func RELRO(name string) *relro {
 	// if DT_FLAGS == 8, then DF_BIND_NOW is set
 	// this is depending on the compiler version used.
 	bind, _ := file.DynValue(elf.DT_BIND_NOW)
+	if (len(bind) == 0) {
+		bind, _ = DynValueFromPTDynamic(file, elf.DT_BIND_NOW)
+	}
 	bind_flag, _ := file.DynValue(elf.DT_FLAGS)
+	if (len(bind_flag) == 0) {
+		bind_flag, _ = DynValueFromPTDynamic(file, elf.DT_FLAGS)
+	}
 
 	if (len(bind) > 0 && bind[0] == 0) || (len(bind_flag) > 0 && bind_flag[0] == 8) {
 		bindNow = true

--- a/pkg/checksec/symbols.go
+++ b/pkg/checksec/symbols.go
@@ -1,7 +1,9 @@
 package checksec
 
 import (
+	"bytes"
 	"debug/elf"
+	"encoding/binary"
 	"fmt"
 	"os"
 )
@@ -30,4 +32,141 @@ func SYMBOLS(name string) *symbols {
 		res.Color = "red"
 	}
 	return &res
+}
+
+func DynValueFromPTDynamic(file *elf.File, tag elf.DynTag) ([]uint64, error) {
+	var res []uint64
+
+	for _, prog := range file.Progs {
+		if prog.Type == elf.PT_DYNAMIC {
+			data := make([]byte, prog.Filesz)
+			_, err := prog.ReadAt(data, 0)
+			if err != nil {
+				fmt.Println("Error reading dynamic section:", err)
+				return res, err
+			}
+
+			if file.Class == elf.ELFCLASS64 {
+				for i := 0; i < len(data); i += 16 { // Each entry is typically 16 bytes
+					if i+8 > len(data) {
+						break
+					}
+					if elf.DynTag(binary.LittleEndian.Uint64(data[i : i+8])) == tag {
+						value := binary.LittleEndian.Uint64(data[i+8 : i+16])
+						return append(res, value), err
+					}
+				}
+			} else {
+				for i := 0; i < len(data); i += 8 { // Each entry is typically 8 bytes
+					if i+4 > len(data) {
+						break
+					}
+					if elf.DynTag(binary.LittleEndian.Uint32(data[i : i+4])) == tag {
+						value := uint64(binary.LittleEndian.Uint32(data[i+4 : i+8]))
+						return append(res, value), err
+					}
+				}
+			}
+		}
+	}
+	return res, nil
+}
+
+func FunctionsFromSymbolTable(file *os.File) ([]elf.Symbol, error) {
+	// Iterate over the dynamic section to handle stripped binaries with no sections
+	var functions []elf.Symbol
+
+	f, err := elf.NewFile(file)
+	if err != nil {
+		fmt.Println("Error parsing ELF file:", err)
+		return functions, err
+	}
+
+	symTabOffset, _ := DynValueFromPTDynamic(f, elf.DT_SYMTAB)
+	strTabOffset, _ := DynValueFromPTDynamic(f, elf.DT_STRTAB)
+	strTabSize, _ := DynValueFromPTDynamic(f, elf.DT_STRSZ)
+
+	// Read the symbol table
+	symData := make([]byte, symTabOffset[0])
+	_, err = file.ReadAt(symData, int64(symTabOffset[0]))
+	if err != nil {
+		fmt.Println("Error reading symbol table:", err)
+		return functions, err
+	}
+
+	// Read the string table
+	strData := make([]byte, strTabSize[0])
+	_, err = file.ReadAt(strData, int64(strTabOffset[0]))
+	if err != nil {
+		fmt.Println("Error reading string table:", err)
+		return functions, err
+	}
+
+	// Determine the size of the symbol entry based on architecture
+	var symSize int
+	var is64Bit bool
+	if f.Class == elf.ELFCLASS32 {
+		symSize = binary.Size(elf.Sym32{})
+		is64Bit = false
+	} else {
+		symSize = binary.Size(elf.Sym64{})
+		is64Bit = true
+	}
+
+	// Iterate over the symbol table to extract function names
+	for i := 0; i < len(symData); i += symSize {
+		if i+symSize > len(symData) {
+			break
+		}
+		if is64Bit {
+			sym := elf.Sym64{}
+			err := binary.Read(bytes.NewReader(symData[i:i+symSize]), binary.LittleEndian, &sym)
+			if err != nil {
+				fmt.Println("Error reading symbol:", err)
+				continue
+			}
+
+			// Check if the symbol is a function
+			if elf.STT_FUNC == elf.SymType(sym.Info&0x0F) {
+				// Ensure the index is within bounds
+				if int(sym.Name) < len(strData) {
+					funcName := strData[sym.Name:]
+					// Find the end of the string
+					endIndex := 0
+					for endIndex = 0; endIndex < len(funcName); endIndex++ {
+						if funcName[endIndex] == 0 {
+							break
+						}
+					}
+					function := elf.Symbol{Name: string(funcName[:endIndex])}
+					functions = append(functions, function)
+				}
+			}
+		} else {
+			sym := elf.Sym32{}
+			err := binary.Read(bytes.NewReader(symData[i:i+symSize]), binary.LittleEndian, &sym)
+			if err != nil {
+				fmt.Println("Error reading symbol:", err)
+				continue
+			}
+
+			// Check if the symbol is a function
+			if elf.STT_FUNC == elf.SymType(sym.Info&0x0F) {
+				// Ensure the index is within bounds
+				if int(sym.Name) < len(strData) {
+					funcName := strData[sym.Name:]
+					// Find the end of the string
+					endIndex := 0
+					for endIndex = 0; endIndex < len(funcName); endIndex++ {
+						if funcName[endIndex] == 0 {
+							break
+						}
+					}
+					function := elf.Symbol{Name: string(funcName[:endIndex])}
+					functions = append(functions, function)
+				}
+			}
+		}
+	}
+	return functions, err
 }

--- a/pkg/utils/checks.go
+++ b/pkg/utils/checks.go
@@ -7,7 +7,7 @@ import (
 )
 
 // RunFileChecks - Run the file checks
-func RunFileChecks(filename string) ([]interface{}, []interface{}) {
+func RunFileChecks(filename string, libc string) ([]interface{}, []interface{}) {
 
 	binary := GetBinary(filename)
 	relro := checksec.RELRO(filename)
@@ -17,7 +17,7 @@ func RunFileChecks(filename string) ([]interface{}, []interface{}) {
 	rpath := checksec.RPATH(filename)
 	runpath := checksec.RUNPATH(filename)
 	symbols := checksec.SYMBOLS(filename)
-	fortify := checksec.Fortify(filename, binary)
+	fortify := checksec.Fortify(filename, binary, libc)
 
 	data := []interface{}{
 		map[string]interface{}{


### PR DESCRIPTION
Some embedded binaries are heavily stripped (i.e. no sections) resulting in wrong results for Canary, FORTIFY and Full RELRO

The shell version of checksec handled those binaries thanks to the `--use-dynamic` option of readelf since
https://github.com/slimm609/checksec/commit/9885afd8b87dde3207ddcbb51fece9b62046a740

So, add back this mechanism in go version to handle Canary and Full RELRO. Current mechanism handles 32 and 64 bits Little Endian binaries.

FORTIFY is more complicated to handle as `uroot.FList` returns an empty list on most embedded binaries. So, an additional parameter is added to let the user specify where libc is located.