### PR TITLE
Handle kernel modules

### DIFF
--- a/pkg/checksec/nx.go
+++ b/pkg/checksec/nx.go
@@ -11,6 +11,11 @@ type nx struct {
 
 func NX(name string, binary *elf.File) *nx {
 	res := nx{}
+	if len(binary.Progs) == 0 {
+		res.Color = "italic"
+		res.Output = "N/A"
+		return &res
+	}
 	for _, p := range binary.Progs {
 		if p.Type == elf.PT_GNU_STACK && p.Flags&elf.PF_X == 0 {
 			res.Color = "green"

--- a/pkg/checksec/pie.go
+++ b/pkg/checksec/pie.go
@@ -11,13 +11,17 @@ type pie struct {
 
 func PIE(name string, binary *elf.File) *pie {
 	res := pie{}
-	if binary.Type == elf.ET_DYN {
+	switch binary.Type {
+	case elf.ET_DYN:
 		res.Color = "green"
 		res.Output = "PIE Enabled"
-		return &res
+	case elf.ET_REL:
+		res.Color = "yellow"
+		res.Output = "REL"
+	default:
+		res.Color = "red"
+		res.Output = "PIE Disabled"
 	}
 
-	res.Color = "red"
-	res.Output = "PIE Disabled"
 	return &res
 }

--- a/pkg/checksec/relro.go
+++ b/pkg/checksec/relro.go
@@ -25,6 +25,12 @@ func RELRO(name string) *relro {
 	}
 	defer file.Close()
 
+	if len(file.Progs) == 0 {
+		res.Color = "italic"
+		res.Output = "N/A"
+		return &res
+	}
+
 	// check both bind and bind_flag.
 	// if DT_BIND_NOW == 0, then it is set
 	// if DT_FLAGS == 8, then DF_BIND_NOW is set


### PR DESCRIPTION
Kernel module has no program sections so return N/A for NX and RELRO to keep the same behavior than shell version of checksec: https://github.com/slimm609/checksec/commit/5d360c56e2fb14edaea96af758aabfa8ca8495e7

Moreover, return REL in yellow for relocatable file (such as kernel module) to also keep the same behavior than shell version of checksec: https://github.com/slimm609/checksec/commit/4aef3708c31f209ca252c537a450c5ec034f09da