### PR TITLE
fix failure with static binaries

### DIFF
--- a/pkg/checksec/symbols.go
+++ b/pkg/checksec/symbols.go
@@ -86,6 +86,10 @@ func FunctionsFromSymbolTable(file *os.File) ([]elf.Symbol, error) {
 	strTabOffset, _ := DynValueFromPTDynamic(f, elf.DT_STRTAB)
 	strTabSize, _ := DynValueFromPTDynamic(f, elf.DT_STRSZ)
 
+	if symTabOffset == nil || strTabSize == nil || strTabOffset == nil {
+		return functions, err
+	}
+
 	// Read the symbol table
 	symData := make([]byte, symTabOffset[0])
 	_, err = file.ReadAt(symData, int64(symTabOffset[0]))


### PR DESCRIPTION
Fix the following failure (raised since commit 325d53bc02617e6848f42ca69d074a140676ea2d) with statically linked binaries such as `/usr/bin/go` which don't have `SYMTAB`:

```
panic: runtime error: index out of range [0] with length 0

goroutine 1 [running]:
github.com/slimm609/checksec/pkg/checksec.FunctionsFromSymbolTable(0x86c044168)
        /home/freebsd/checksec-src/pkg/checksec/symbols.go:90 +0xb0f
```

Fix #291