### PR TITLE
Add support for ARM PAC/BTI and x86 SHSTK/IBT file checks

### DIFF
--- a/pkg/checksec/cfi.go
+++ b/pkg/checksec/cfi.go
@@ -1,0 +1,182 @@
+package checksec
+
+import (
+	"debug/elf"
+	"fmt"
+	"os"
+)
+
+type cfi struct {
+	Output string
+	Color  string
+}
+
+type x86CET struct {
+	shstk bool
+	ibt   bool
+}
+
+type armPACBTI struct {
+	pac bool
+	bti bool
+}
+
+const GnuPropertyArmFeature1Flag uint32 = 0xc0000000
+const GnuPropertyX86Feature1Flag uint32 = 0xc0000002
+
+const (
+	GnuPropertyX86FeatureIBT uint32 = 1 << iota
+	GnuPropertyX86FeatureSHSTK
+)
+
+const (
+	GnuPropertyArmFeatureBTI uint32 = 1 << iota
+	GnuPropertyArmFeaturePAC
+)
+
+func Cfi(name string) *cfi {
+	f, err := os.Open(name)
+	if err != nil {
+		fmt.Println("Error:", err)
+		os.Exit(1)
+	}
+	defer f.Close()
+	file, err := elf.NewFile(f)
+	if err != nil {
+		fmt.Println("Error parsing ELF file:", err)
+		os.Exit(1)
+	}
+	res := cfi{}
+	notes := file.Section(".note.gnu.property")
+	if notes == nil {
+		resUnknown(&res)
+		return &res
+	}
+
+	propertyData, err := notes.Data()
+	if err != nil {
+		resUnknown(&res)
+		return &res
+	}
+
+	// Property data layout of the relevant sections in ELFCLASS64
+	// |0                  |1
+	// |0|1|2|3|4|5|6|7|8|9|0|1|2|3|4|5|
+	// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	// | type  |datasz | btmsk |  pad  |
+	// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	if file.Class == elf.ELFCLASS64 && file.Machine == elf.EM_X86_64 {
+		// x86-64, check for Shadow Stack and IBT
+		// https://docs.kernel.org/next/x86/shstk.html
+		// https://www.intel.com/content/www/us/en/developer/articles/technical/technical-look-control-flow-enforcement-technology.html
+		var parsedSupport x86CET
+		i := 0
+		for i < len(propertyData) {
+			notetype := file.ByteOrder.Uint32(propertyData[i : i+4])
+			datasz := file.ByteOrder.Uint32(propertyData[i+4 : i+8])
+			i += 8
+			if datasz != 4 {
+				continue
+			}
+			bitmask := file.ByteOrder.Uint32(propertyData[i : i+4])
+			if notetype == GnuPropertyX86Feature1Flag {
+				parsedSupport = parseBitmaskForx86CET(bitmask)
+			}
+			i += 8
+		}
+
+		if parsedSupport.shstk && parsedSupport.ibt {
+			res.Color = "green"
+			res.Output = "SHSTK & IBT"
+		} else if parsedSupport.shstk {
+			res.Color = "yellow"
+			res.Output = "SHSTK & NO IBT"
+		} else if parsedSupport.ibt {
+			res.Color = "yellow"
+			res.Output = " NO SHSTK & IBT"
+		} else {
+			res.Color = "red"
+			res.Output = "NO SHSTK & NO IBT"
+		}
+	} else if file.Class == elf.ELFCLASS64 && file.Machine == elf.EM_AARCH64 {
+		// AARCH64, check for PAC and BTI
+		// https://docs.kernel.org/arch/arm64/pointer-authentication.html
+		// https://community.arm.com/arm-community-blogs/b/architectures-and-processors-blog/posts/armv8-1-m-pointer-authentication-and-branch-target-identification-extension
+		var parsedSupport armPACBTI
+		i := 0
+		for i < len(propertyData) {
+			notetype := file.ByteOrder.Uint32(propertyData[i : i+4])
+			datasz := file.ByteOrder.Uint32(propertyData[i+4 : i+8])
+			i += 8
+			if datasz != 4 {
+				continue
+			}
+			bitmask := file.ByteOrder.Uint32(propertyData[i : i+4])
+			if notetype == GnuPropertyArmFeature1Flag {
+				parsedSupport = parseBitmaskForArmPACBTI(bitmask)
+			}
+			i += 8
+		}
+
+		if parsedSupport.pac && parsedSupport.bti {
+			res.Color = "green"
+			res.Output = "PAC & BTI"
+		} else if parsedSupport.pac {
+			res.Color = "yellow"
+			res.Output = "PAC & NO BTI"
+		} else if parsedSupport.bti {
+			res.Color = "yellow"
+			res.Output = "NO PAC & BTI"
+		} else {
+			res.Color = "red"
+			res.Output = "NO PAC & NO BTI"
+		}
+	} else {
+		resUnknown(&res)
+	}
+
+	return &res
+}
+
+func parseBitmaskForx86CET(bitmask uint32) x86CET {
+	result := x86CET{
+		shstk: false,
+		ibt:   false,
+	}
+	for bitmask > 0 {
+		bit := bitmask & (-bitmask)
+		bitmask &= ^bit
+
+		switch bit {
+		case GnuPropertyX86FeatureIBT:
+			result.ibt = true
+		case GnuPropertyX86FeatureSHSTK:
+			result.shstk = true
+		}
+	}
+	return result
+}
+
+func parseBitmaskForArmPACBTI(bitmask uint32) armPACBTI {
+	result := armPACBTI{
+		pac: false,
+		bti: false,
+	}
+	for bitmask > 0 {
+		bit := bitmask & (-bitmask)
+		bitmask &= ^bit
+
+		switch bit {
+		case GnuPropertyArmFeaturePAC:
+			result.pac = true
+		case GnuPropertyArmFeatureBTI:
+			result.bti = true
+		}
+	}
+	return result
+}
+
+func resUnknown(emptyCfi *cfi) {
+	emptyCfi.Color = "yellow"
+	emptyCfi.Output = "Unknown"
+}

--- a/pkg/checksec/cfi_test.go
+++ b/pkg/checksec/cfi_test.go
@@ -1,0 +1,45 @@
+package checksec
+
+import "testing"
+
+func TestX86CFI(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    uint32
+		expected x86CET
+	}{
+		{"no shstk & no ibt", 0, x86CET{shstk: false, ibt: false}},
+		{"no shstk & ibt", 1, x86CET{shstk: false, ibt: true}},
+		{"shstk & no ibt", 2, x86CET{shstk: true, ibt: false}},
+		{"shstk & ibt", 3, x86CET{shstk: true, ibt: true}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res := parseBitmaskForx86CET(tt.input)
+			if res != tt.expected {
+				t.Errorf("got %v, want %v", res, tt.expected)
+			}
+		})
+	}
+}
+
+func TestArmPACBTI(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    uint32
+		expected armPACBTI
+	}{
+		{"no pac & no bti", 0, armPACBTI{pac: false, bti: false}},
+		{"no pac & bti", 1, armPACBTI{pac: false, bti: true}},
+		{"pac & no bti", 2, armPACBTI{pac: true, bti: false}},
+		{"pac & bti", 3, armPACBTI{pac: true, bti: true}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res := parseBitmaskForArmPACBTI(tt.input)
+			if res != tt.expected {
+				t.Errorf("got %v, want %v", res, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/utils/checks.go
+++ b/pkg/utils/checks.go
@@ -12,6 +12,7 @@ func RunFileChecks(filename string, libc string) ([]interface{}, []interface{}) 
 	binary := GetBinary(filename)
 	relro := checksec.RELRO(filename)
 	canary := checksec.Canary(filename)
+	cfi := checksec.Cfi(filename)
 	nx := checksec.NX(filename, binary)
 	pie := checksec.PIE(filename, binary)
 	rpath := checksec.RPATH(filename)
@@ -25,6 +26,7 @@ func RunFileChecks(filename string, libc string) ([]interface{}, []interface{}) 
 			"checks": map[string]interface{}{
 				"relro":          relro.Output,
 				"canary":         canary.Output,
+				"cfi":            cfi.Output,
 				"nx":             nx.Output,
 				"pie":            pie.Output,
 				"rpath":          rpath.Output,
@@ -43,6 +45,8 @@ func RunFileChecks(filename string, libc string) ([]interface{}, []interface{}) 
 			"checks": map[string]interface{}{
 				"canary":              canary.Output,
 				"canaryColor":         canary.Color,
+				"cfi":                 cfi.Output,
+				"cfiColor":            cfi.Color,
 				"fortified":           fortify.Fortified,
 				"fortifiedColor":      "unset",
 				"fortifyable":         fortify.Fortifiable,

--- a/pkg/utils/filePrinter.go
+++ b/pkg/utils/filePrinter.go
@@ -30,6 +30,8 @@ type SecurityCheckColor struct {
 	Checks struct {
 		Canary             string `json:"canary"`
 		CanaryColor        string `json:"canaryColor"`
+		Cfi                string `json:"cfi"`
+		CfiColor           string `json:"cfiColor"`
 		Fortified          string `json:"fortified"`
 		FortifyAble        string `json:"fortifyable"`
 		FortifySource      string `json:"fortify_source"`
@@ -90,9 +92,10 @@ func FilePrinter(outputFormat string, data interface{}, colors interface{}, noBa
 			return
 		}
 		if !noHeader {
-			fmt.Printf("%-24s%-26s%-22s%-24s%-19s%-21s%-24s%-19s%-20s%-25s%-40s\n",
+			fmt.Printf("%-24s%-26s%-26s%-22s%-24s%-19s%-21s%-24s%-19s%-20s%-25s%-40s\n",
 				colorPrinter("RELRO", "unset"),
 				colorPrinter("Stack Canary", "unset"),
+				colorPrinter("CFI", "unset"),
 				colorPrinter("NX", "unset"),
 				colorPrinter("PIE", "unset"),
 				colorPrinter("RPATH", "unset"),
@@ -105,9 +108,10 @@ func FilePrinter(outputFormat string, data interface{}, colors interface{}, noBa
 			)
 		}
 		for _, check := range securityChecksColors {
-			fmt.Printf("%-25s%-27s%-23s%-25s%-20s%-22s%-25s%-20s%-20s%-25s%-40s\n",
+			fmt.Printf("%-25s%-27s%-27s%-23s%-25s%-20s%-22s%-25s%-20s%-20s%-25s%-40s\n",
 				colorPrinter(check.Checks.Relro, check.Checks.RelroColor),
 				colorPrinter(check.Checks.Canary, check.Checks.CanaryColor),
+				colorPrinter(check.Checks.Cfi, check.Checks.CfiColor),
 				colorPrinter(check.Checks.NX, check.Checks.NXColor),
 				colorPrinter(check.Checks.PIE, check.Checks.PIEColor),
 				colorPrinter(check.Checks.RPath, check.Checks.RPathColor),


### PR DESCRIPTION
Resolves #237 . 

Adds support for ARM PAC/BTI and x86 SHSTK/IBT file checks by parsing the ".note.gnu.property" note in ELF64 binaries. One thing about the current implementation is that if the note is missing entirely or there are problems reading the data it returns "unknown" instead of "no cfi", I'm still thinking if that's the right message to the user or not. 