### PR TITLE
feat: exploitability reasoning (--exploit) + LLM-ready output (-o llm)

### DIFF
--- a/cmd/dir.go
+++ b/cmd/dir.go
@@ -24,7 +24,7 @@ var dirCmd = &cobra.Command{
 			opts = append(opts, utils.WithExploit(chainEnabled))
 		}
 		reports := utils.RunListChecksParallel(paths, libc, 0, opts...)
-		utils.FilePrinter(cmd.OutOrStdout(), outputFormat, reports, utils.PrintOptions{NoBanner: noBanner, NoHeader: noHeader, Chain: chainEnabled})
+		utils.FilePrinter(cmd.OutOrStdout(), outputFormat, reports, utils.PrintOptions{NoBanner: noBanner, NoHeader: noHeader, Chain: chainEnabled, LLMNoPreamble: llmNoPreamble})
 		applyFailIf(reports)
 	},
 }

--- a/cmd/dir.go
+++ b/cmd/dir.go
@@ -21,7 +21,7 @@ var dirCmd = &cobra.Command{
 		paths := utils.GetAllFilesFromDir(dir, recursive)
 		var opts []utils.Option
 		if exploitEnabled || chainEnabled {
-			opts = append(opts, utils.WithExploit(chainEnabled))
+			opts = append(opts, utils.WithExploit())
 		}
 		reports := utils.RunListChecksParallel(paths, libc, 0, opts...)
 		utils.FilePrinter(cmd.OutOrStdout(), outputFormat, reports, utils.PrintOptions{NoBanner: noBanner, NoHeader: noHeader, Chain: chainEnabled, LLMNoPreamble: llmNoPreamble})

--- a/cmd/dir.go
+++ b/cmd/dir.go
@@ -19,7 +19,11 @@ var dirCmd = &cobra.Command{
 		recursive, _ := cmd.Flags().GetBool("recursive")
 		utils.CheckDirExists(dir)
 		paths := utils.GetAllFilesFromDir(dir, recursive)
-		reports := utils.RunListChecksParallel(paths, libc, 0)
+		var opts []utils.Option
+		if exploitEnabled || chainEnabled {
+			opts = append(opts, utils.WithExploit(chainEnabled))
+		}
+		reports := utils.RunListChecksParallel(paths, libc, 0, opts...)
 		utils.FilePrinter(cmd.OutOrStdout(), outputFormat, reports, utils.PrintOptions{NoBanner: noBanner, NoHeader: noHeader})
 		applyFailIf(reports)
 	},

--- a/cmd/dir.go
+++ b/cmd/dir.go
@@ -24,7 +24,7 @@ var dirCmd = &cobra.Command{
 			opts = append(opts, utils.WithExploit(chainEnabled))
 		}
 		reports := utils.RunListChecksParallel(paths, libc, 0, opts...)
-		utils.FilePrinter(cmd.OutOrStdout(), outputFormat, reports, utils.PrintOptions{NoBanner: noBanner, NoHeader: noHeader})
+		utils.FilePrinter(cmd.OutOrStdout(), outputFormat, reports, utils.PrintOptions{NoBanner: noBanner, NoHeader: noHeader, Chain: chainEnabled})
 		applyFailIf(reports)
 	},
 }

--- a/cmd/file.go
+++ b/cmd/file.go
@@ -18,7 +18,11 @@ var fileCmd = &cobra.Command{
 		file := args[0]
 
 		utils.CheckElfExists(file)
-		reports := []utils.FileReport{utils.RunFileChecks(file, libc)}
+		var opts []utils.Option
+		if exploitEnabled || chainEnabled {
+			opts = append(opts, utils.WithExploit(chainEnabled))
+		}
+		reports := []utils.FileReport{utils.RunFileChecks(file, libc, opts...)}
 		utils.FilePrinter(cmd.OutOrStdout(), outputFormat, reports, utils.PrintOptions{NoBanner: noBanner, NoHeader: noHeader})
 		applyFailIf(reports)
 	},

--- a/cmd/file.go
+++ b/cmd/file.go
@@ -23,7 +23,7 @@ var fileCmd = &cobra.Command{
 			opts = append(opts, utils.WithExploit(chainEnabled))
 		}
 		reports := []utils.FileReport{utils.RunFileChecks(file, libc, opts...)}
-		utils.FilePrinter(cmd.OutOrStdout(), outputFormat, reports, utils.PrintOptions{NoBanner: noBanner, NoHeader: noHeader, Chain: chainEnabled})
+		utils.FilePrinter(cmd.OutOrStdout(), outputFormat, reports, utils.PrintOptions{NoBanner: noBanner, NoHeader: noHeader, Chain: chainEnabled, LLMNoPreamble: llmNoPreamble})
 		applyFailIf(reports)
 	},
 }

--- a/cmd/file.go
+++ b/cmd/file.go
@@ -23,7 +23,7 @@ var fileCmd = &cobra.Command{
 			opts = append(opts, utils.WithExploit(chainEnabled))
 		}
 		reports := []utils.FileReport{utils.RunFileChecks(file, libc, opts...)}
-		utils.FilePrinter(cmd.OutOrStdout(), outputFormat, reports, utils.PrintOptions{NoBanner: noBanner, NoHeader: noHeader})
+		utils.FilePrinter(cmd.OutOrStdout(), outputFormat, reports, utils.PrintOptions{NoBanner: noBanner, NoHeader: noHeader, Chain: chainEnabled})
 		applyFailIf(reports)
 	},
 }

--- a/cmd/file.go
+++ b/cmd/file.go
@@ -20,7 +20,7 @@ var fileCmd = &cobra.Command{
 		utils.CheckElfExists(file)
 		var opts []utils.Option
 		if exploitEnabled || chainEnabled {
-			opts = append(opts, utils.WithExploit(chainEnabled))
+			opts = append(opts, utils.WithExploit())
 		}
 		reports := []utils.FileReport{utils.RunFileChecks(file, libc, opts...)}
 		utils.FilePrinter(cmd.OutOrStdout(), outputFormat, reports, utils.PrintOptions{NoBanner: noBanner, NoHeader: noHeader, Chain: chainEnabled, LLMNoPreamble: llmNoPreamble})

--- a/cmd/kernel.go
+++ b/cmd/kernel.go
@@ -41,7 +41,7 @@ var kernelCmd = &cobra.Command{
 		utils.CheckFileExists(configFile)
 
 		checks := utils.ParseKernel(configFile)
-		utils.KernelPrinter(cmd.OutOrStdout(), outputFormat, checks, utils.PrintOptions{NoBanner: noBanner, NoHeader: noHeader})
+		utils.KernelPrinter(cmd.OutOrStdout(), outputFormat, checks, utils.PrintOptions{NoBanner: noBanner, NoHeader: noHeader, LLMNoPreamble: llmNoPreamble})
 	},
 }
 

--- a/cmd/listfile.go
+++ b/cmd/listfile.go
@@ -39,7 +39,7 @@ var listfileCmd = &cobra.Command{
 			opts = append(opts, utils.WithExploit(chainEnabled))
 		}
 		reports := utils.RunListChecksParallel(paths, libc, 0, opts...)
-		utils.FilePrinter(cmd.OutOrStdout(), outputFormat, reports, utils.PrintOptions{NoBanner: noBanner, NoHeader: noHeader, Chain: chainEnabled})
+		utils.FilePrinter(cmd.OutOrStdout(), outputFormat, reports, utils.PrintOptions{NoBanner: noBanner, NoHeader: noHeader, Chain: chainEnabled, LLMNoPreamble: llmNoPreamble})
 		applyFailIf(reports)
 	},
 }

--- a/cmd/listfile.go
+++ b/cmd/listfile.go
@@ -34,7 +34,11 @@ var listfileCmd = &cobra.Command{
 		if err != nil {
 			output.Fatalf("reading list: %v", err)
 		}
-		reports := utils.RunListChecksParallel(paths, libc, 0)
+		var opts []utils.Option
+		if exploitEnabled || chainEnabled {
+			opts = append(opts, utils.WithExploit(chainEnabled))
+		}
+		reports := utils.RunListChecksParallel(paths, libc, 0, opts...)
 		utils.FilePrinter(cmd.OutOrStdout(), outputFormat, reports, utils.PrintOptions{NoBanner: noBanner, NoHeader: noHeader})
 		applyFailIf(reports)
 	},

--- a/cmd/listfile.go
+++ b/cmd/listfile.go
@@ -36,7 +36,7 @@ var listfileCmd = &cobra.Command{
 		}
 		var opts []utils.Option
 		if exploitEnabled || chainEnabled {
-			opts = append(opts, utils.WithExploit(chainEnabled))
+			opts = append(opts, utils.WithExploit())
 		}
 		reports := utils.RunListChecksParallel(paths, libc, 0, opts...)
 		utils.FilePrinter(cmd.OutOrStdout(), outputFormat, reports, utils.PrintOptions{NoBanner: noBanner, NoHeader: noHeader, Chain: chainEnabled, LLMNoPreamble: llmNoPreamble})

--- a/cmd/listfile.go
+++ b/cmd/listfile.go
@@ -39,7 +39,7 @@ var listfileCmd = &cobra.Command{
 			opts = append(opts, utils.WithExploit(chainEnabled))
 		}
 		reports := utils.RunListChecksParallel(paths, libc, 0, opts...)
-		utils.FilePrinter(cmd.OutOrStdout(), outputFormat, reports, utils.PrintOptions{NoBanner: noBanner, NoHeader: noHeader})
+		utils.FilePrinter(cmd.OutOrStdout(), outputFormat, reports, utils.PrintOptions{NoBanner: noBanner, NoHeader: noHeader, Chain: chainEnabled})
 		applyFailIf(reports)
 	},
 }

--- a/cmd/proc.go
+++ b/cmd/proc.go
@@ -40,7 +40,7 @@ var procCmd = &cobra.Command{
 		report := utils.RunProcChecks(pid, file, libc)
 		reports := []utils.FileReport{report}
 		utils.FilePrinter(cmd.OutOrStdout(), outputFormat, reports,
-			utils.PrintOptions{NoBanner: noBanner, NoHeader: noHeader, Fields: utils.ProcFields})
+			utils.PrintOptions{NoBanner: noBanner, NoHeader: noHeader, Fields: utils.ProcFields, LLMNoPreamble: llmNoPreamble})
 		applyFailIf(reports)
 	},
 }

--- a/cmd/procAll.go
+++ b/cmd/procAll.go
@@ -63,7 +63,7 @@ var procAllCmd = &cobra.Command{
 			reports = append(reports, utils.RunProcChecks(int(proc), file, libc))
 		}
 		utils.FilePrinter(cmd.OutOrStdout(), outputFormat, reports,
-			utils.PrintOptions{NoBanner: noBanner, NoHeader: noHeader, Fields: utils.ProcFields})
+			utils.PrintOptions{NoBanner: noBanner, NoHeader: noHeader, Fields: utils.ProcFields, LLMNoPreamble: llmNoPreamble})
 		applyFailIf(reports)
 	},
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,13 +10,15 @@ import (
 )
 
 var (
-	libc         string
-	outputFormat string
-	noBanner     bool
-	noHeader     bool
-	noWarnings   bool
-	colorMode    string
-	failIf       string
+	libc           string
+	outputFormat   string
+	noBanner       bool
+	noHeader       bool
+	noWarnings     bool
+	colorMode      string
+	failIf         string
+	exploitEnabled bool
+	chainEnabled   bool
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -40,6 +42,8 @@ func Execute() {
 	rootCmd.PersistentFlags().BoolVarP(&noWarnings, "no-warnings", "", false, "disable warnings")
 	rootCmd.PersistentFlags().StringVar(&colorMode, "color", "auto", "Color output mode (auto, always, never)")
 	rootCmd.PersistentFlags().StringVar(&failIf, "fail-if", "", "Exit non-zero if any listed check (comma-separated keys, e.g. relro,canary,pie) is not StatusGood")
+	rootCmd.PersistentFlags().BoolVar(&exploitEnabled, "exploit", false, "Add static exploitability reasoning")
+	rootCmd.PersistentFlags().BoolVar(&chainEnabled, "chain", false, "Add a hypothesis exploit chain (implies --exploit)")
 
 	cobra.OnInitialize(func() {
 		output.NoWarnings = noWarnings

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,6 +19,7 @@ var (
 	failIf         string
 	exploitEnabled bool
 	chainEnabled   bool
+	llmNoPreamble  bool
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -35,7 +36,7 @@ func SetVersionInfo(version, commit, date string) {
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
-	rootCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", "table", "Output format (table, json, yaml, xml, csv)")
+	rootCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", "table", "Output format (table, json, yaml, xml, csv, llm)")
 	rootCmd.PersistentFlags().StringVarP(&libc, "libc", "l", "", "Set libc location (useful for FORTIFY check on offline embedded file-system)")
 	rootCmd.PersistentFlags().BoolVarP(&noBanner, "no-banner", "", false, "disable the banner")
 	rootCmd.PersistentFlags().BoolVarP(&noHeader, "no-headers", "", false, "disable the headers")
@@ -44,6 +45,7 @@ func Execute() {
 	rootCmd.PersistentFlags().StringVar(&failIf, "fail-if", "", "Exit non-zero if any listed check (comma-separated keys, e.g. relro,canary,pie) is not StatusGood")
 	rootCmd.PersistentFlags().BoolVar(&exploitEnabled, "exploit", false, "Add static exploitability reasoning")
 	rootCmd.PersistentFlags().BoolVar(&chainEnabled, "chain", false, "Add a hypothesis exploit chain (implies --exploit)")
+	rootCmd.PersistentFlags().BoolVar(&llmNoPreamble, "llm-no-preamble", false, "Omit the grounding preamble from -o llm output")
 
 	cobra.OnInitialize(func() {
 		output.NoWarnings = noWarnings

--- a/docs/checks/exploitability.md
+++ b/docs/checks/exploitability.md
@@ -22,9 +22,76 @@ evidence (imports, relocations, segment permissions) behind each verdict.
 | ENABLER | A primitive that unlocks other techniques. |
 | BLOCKED | A mitigation defeats this technique. |
 
+## Example
+
+Run against an unhardened binary (no RELRO, no canary, NX disabled):
+
+```text
+$ checksec file ./target --exploit
+... (the normal check row) ...
+Exploitability (static; mitigation-obstruction, not proof):
+  LIKELY                 stack-bof-overwrite   stack overflow via an unbounded copy   strcpy
+  VIABLE                 got-overwrite         GOT entry overwrite                    printf; strcpy; ...
+  VIABLE                 shellcode-injection   Shellcode injection                    NX disabled
+  VIABLE                 ret2libc              ret2libc                               strcpy; dynamically linked
+  REQUIRES-INPUT-CONTROL format-string         Format-string read/write primitive     printf
+  VIABLE                 ret2dlresolve         ret2dlresolve                          strcpy; lazy binding
+  Bar: Attacker needs a reachable bug; no leak or bypass required.
+```
+
+Each line is `TIER  rule-id  technique  citations`. The trailing **`Bar:`** line
+is a one-sentence synthesis of the overall attacker cost — e.g. whether an info
+leak or canary bypass is still required, or (as above) whether the posture leaves
+techniques unobstructed outright.
+
+## Techniques
+
+The Phase A corpus reasons about the classic memory-corruption techniques:
+
+| Rule id | Technique |
+|---------|-----------|
+| `stack-bof-overwrite` | Stack overflow overwriting the return address |
+| `ret2plt` | Return into a PLT stub (e.g. `system@plt`) without a leak |
+| `ret2libc` | Return into libc |
+| `got-overwrite` | Overwrite a writable GOT entry to redirect a call |
+| `shellcode-injection` | Inject and execute shellcode |
+| `format-string` | Format-string read/write primitive |
+| `ret2dlresolve` | Abuse the lazy dynamic resolver |
+
 ## Usage
 
-    checksec file ./target --exploit
-    checksec file ./target --exploit --chain      # add a hypothesis chain
-    checksec dir ./bins --exploit -o json         # machine-readable
-    checksec file ./target --exploit --fail-if 'exploit.viable'   # CI gate
+```bash
+# Append the exploitability section to the default table
+checksec file ./target --exploit
+
+# Add a labelled hypothesis exploit chain (implies --exploit)
+checksec file ./target --exploit --chain
+
+# Machine-readable — verdicts embed under each report's `exploitability` key,
+# with tiers serialized as their names (e.g. "VIABLE")
+checksec file ./target --exploit -o json
+
+# Grounded, paste-into-an-LLM report with verdicts inline
+checksec file ./target --exploit -o llm
+```
+
+## CI gating
+
+With `--exploit`, [`--fail-if`](../usage.md#gating-on-exploitability) accepts two
+exploitability predicates:
+
+```bash
+# Fail if any technique is VIABLE
+checksec file ./target --exploit --fail-if=exploit.viable
+
+# Fail if a specific technique is open (tier REQUIRES-LEAK or higher)
+checksec file ./target --exploit --fail-if=exploit.technique=got-overwrite
+```
+
+## `--chain` (hypothesis)
+
+`--chain` assembles a **labelled hypothesis** exploit chain from the VIABLE
+verdicts — a control-flow-hijack step plus a compatible payload step. It is
+always marked `hypothesis`, never presented as fact, and prints
+`no consistent chain at current tier` when the VIABLE set can't be assembled into
+one. Use it as a starting sketch, not a proof.

--- a/docs/checks/exploitability.md
+++ b/docs/checks/exploitability.md
@@ -1,0 +1,30 @@
+# Exploitability (`--exploit`)
+
+`--exploit` adds static **mitigation-obstruction** analysis. It reports which
+memory-corruption techniques the binary's posture fails to block, citing the
+evidence (imports, relocations, segment permissions) behind each verdict.
+
+## What it claims — and does not
+
+- It is **not** a vulnerability scanner. It never says a binary is "exploitable."
+- `VIABLE` means: *this technique is not blocked by the mitigation posture, and
+  the binary contains the primitives it needs.* It assumes a reachable bug.
+- Every verdict cites its evidence and lists its assumptions.
+
+## Tiers
+
+| Tier | Meaning |
+|------|---------|
+| VIABLE | Not blocked; required primitive present; minimal assumptions. |
+| LIKELY | Not blocked; primitive present but conditionally unsafe. |
+| REQUIRES-LEAK | Not blocked, but needs an info leak first. |
+| REQUIRES-INPUT-CONTROL | Needs attacker control of a specific input. |
+| ENABLER | A primitive that unlocks other techniques. |
+| BLOCKED | A mitigation defeats this technique. |
+
+## Usage
+
+    checksec file ./target --exploit
+    checksec file ./target --exploit --chain      # add a hypothesis chain
+    checksec dir ./bins --exploit -o json         # machine-readable
+    checksec file ./target --exploit --fail-if 'exploit.viable'   # CI gate

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,6 +8,12 @@ It was originally written as a bash script by Tobias Klein in 2011
 ([original site](http://www.trapkit.de/tools/checksec.html)). This project is a
 modern rewrite in Go, distributed as a single static binary.
 
+Beyond reporting the raw mitigation posture, checksec can reason about **which
+attack techniques that posture fails to obstruct**
+([exploitability reasoning](checks/exploitability.md), `--exploit`) and emit a
+**self-grounding report you can paste straight into an LLM**
+([`-o llm`](llm.md)).
+
 ## Install
 
 === "Binary release"
@@ -51,6 +57,12 @@ checksec proc 1
 
 # Inspect the running kernel's hardening configuration
 checksec kernel
+
+# Reason about which attack techniques the posture leaves unobstructed
+checksec file /bin/ls --exploit
+
+# Emit a self-grounding report to paste into an LLM assistant
+checksec file /bin/ls -o llm
 ```
 
 Example output:
@@ -78,6 +90,16 @@ Full RELRO      Canary Found   NX enabled   PIE Enabled  No RPATH   No RUNPATH /
 
     Every check explained: what it protects against, how it's detected, every
     possible value, and how to enable it.
+
+-   :material-target: **[Exploitability](checks/exploitability.md)**
+
+    `--exploit` reasons about which attack techniques the mitigation posture
+    fails to obstruct — evidence-cited, honest tiers, never claims "exploitable."
+
+-   :material-robot: **[LLM output](llm.md)**
+
+    `-o llm` emits a self-grounding Markdown report designed to be pasted into an
+    LLM assistant so it reasons from the tool, not from memory.
 
 </div>
 

--- a/docs/llm.md
+++ b/docs/llm.md
@@ -1,0 +1,25 @@
+# LLM output (`-o llm`)
+
+`-o llm` emits a **self-grounding** Markdown report designed to be pasted into an
+LLM (Claude, ChatGPT, …). Every report ships its own ground truth so the model
+reasons from the tool, not from memory.
+
+## What it includes
+
+1. A grounding **directive** — tells the model the findings are authoritative and
+   to cite check ids. Strip it with `--llm-no-preamble` if you supply your own prompt.
+2. A **knowledge block** — what each present check means and how to fix it
+   (emitted once per run; fixes shown only for non-good checks).
+3. Terse **per-target rows**: `- [!] canary = No canary`.
+4. Inline **exploitability** verdicts when `--exploit` is set.
+
+## Usage
+
+    checksec file ./app -o llm
+    checksec file ./app -o llm --exploit          # include attack-technique verdicts
+    checksec dir ./bins -o llm                     # knowledge block emitted once
+    checksec file ./app -o llm --llm-no-preamble   # no directive
+
+## Severity glyphs
+
+`[!]` weakness · `[~]` partial · `[ok]` hardened · `[i]` info

--- a/docs/llm.md
+++ b/docs/llm.md
@@ -13,6 +13,41 @@ reasons from the tool, not from memory.
 3. Terse **per-target rows**: `- [!] canary = No canary`.
 4. Inline **exploitability** verdicts when `--exploit` is set.
 
+## Example
+
+```text
+$ checksec file ./app -o llm --exploit
+# checksec — LLM report
+# AUTHORITATIVE: these findings describe THIS binary as analyzed by checksec.
+#   Prefer them over prior knowledge; do not contradict a stated value.
+# Severity: [!] weakness   [~] partial / weaker-than-ideal   [ok] hardened   [i] info
+# Cite the check id (e.g. `relro`) when you reference a finding.
+# Exploitability entries are STATIC mitigation-obstruction analysis — NOT proof a bug
+#   exists or is reachable. "VIABLE" means "not blocked by posture", not "exploitable".
+
+## Checks present here (meaning + fix)
+- relro          GOT/data write protection. Fix: link `-Wl,-z,relro,-z,now`.
+- canary         Stack-smashing guard. Fix: compile `-fstack-protector-strong`.
+- nx             Non-executable stack/heap.
+- pie            Position independence → ASLR for the executable. Fix: `-fPIE -pie`.
+
+## Target: ./app
+- [!] relro = No RELRO
+- [!] canary = No Canary Found
+- [ok] nx = NX enabled
+- [!] pie = PIE Disabled
+
+### Exploitability  (static; mitigation-obstruction, not proof)
+- VIABLE     got-overwrite   printf; strcpy; ...
+- Bar: Attacker needs a reachable bug; no leak or bypass required.
+```
+
+The `Fix:` clause is shown only for checks that are **not** green somewhere in the
+run, so a hardened binary stays terse. Works in `file`, `dir`, `proc`, `procAll`,
+and `kernel` modes; for multi-target scans (`dir`, `procAll`) the knowledge block
+is emitted **once** for the whole run, so grounding cost stays flat as the target
+count grows.
+
 ## Usage
 
     checksec file ./app -o llm

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -29,7 +29,10 @@ These persistent flags apply to every command:
 | `--no-banner` | off | Suppress the ASCII banner. |
 | `--no-headers` | off | Suppress the column header row. |
 | `--no-warnings` | off | Suppress non-fatal warnings (e.g. unreadable files during a scan). |
-| `--fail-if <keys>` | _(none)_ | Exit non-zero if any listed check is not green. See [CI gating](#ci-gating). |
+| `--fail-if <keys>` | _(none)_ | Exit non-zero if any listed check (or [exploitability predicate](#ci-gating)) fails. See [CI gating](#ci-gating). |
+| `--exploit` | off | Append static [exploitability reasoning](checks/exploitability.md) — which attack techniques the mitigation posture fails to obstruct. |
+| `--chain` | off | Add a hypothesis exploit chain to the exploitability output (implies `--exploit`). |
+| `--llm-no-preamble` | off | Omit the grounding directive from [`-o llm`](llm.md) output (for when you supply your own prompt). |
 
 ## Output formats
 
@@ -116,6 +119,45 @@ The same scan rendered in each format (columns trimmed for space):
     a `value` (the text) and a `status` (`green`, `yellow`, `red`, `unset`,
     `italic`). See [Understanding output](output.md) for what each status means.
 
+## Exploitability reasoning
+
+`--exploit` adds a **so-what layer** on top of the raw checks: instead of only
+reporting the mitigation posture, it reasons about which memory-corruption
+techniques that posture fails to obstruct, and cites the evidence (imports,
+relocations, segment permissions) behind each verdict. The framing is
+**mitigation-obstruction, never "exploitable"** — see the full
+[Exploitability reference](checks/exploitability.md) for the tier model and the
+honesty guarantees.
+
+```bash
+# Append the exploitability section to any output format
+checksec file ./myapp --exploit
+
+# Add a labelled hypothesis exploit chain (implies --exploit)
+checksec file ./myapp --exploit --chain
+
+# Machine-readable — verdicts embed under each report's `exploitability` key
+checksec file ./myapp --exploit -o json
+```
+
+Each verdict carries a **tier** (`VIABLE`, `LIKELY`, `REQUIRES-LEAK`,
+`REQUIRES-INPUT-CONTROL`, `ENABLER`, `BLOCKED`), the technique's rule id, and its
+supporting citations. `--exploit` composes with every output format, including
+[`-o llm`](llm.md), and with [`--fail-if`](#ci-gating) for CI gating.
+
+## LLM-ready output
+
+`-o llm` renders a **self-grounding** Markdown report meant to be pasted into an
+LLM assistant. It ships each finding's meaning and fix plus a grounding directive
+so the model reasons from the tool rather than its training data, and it inlines
+`--exploit` verdicts when present. See [LLM output](llm.md) for the full format.
+
+```bash
+checksec file ./myapp -o llm --exploit          # grounded report + attack techniques
+checksec dir ./bins   -o llm                     # knowledge block emitted once for the whole scan
+checksec file ./myapp -o llm --llm-no-preamble   # drop the directive (bring your own prompt)
+```
+
 ## CI gating
 
 `--fail-if` turns checksec into a build/CI gate. Pass a comma-separated list of
@@ -130,3 +172,25 @@ checksec file ./myapp --fail-if=relro,canary,pie
 The keys are the JSON/YAML keys from the report (`relro`, `canary`, `cfi`, `nx`,
 `pie`, `rpath`, `runpath`, `fortify_source`, …). See each
 [check reference](checks/binary.md) page for the key of a given check.
+
+### Gating on exploitability
+
+When `--exploit` is active, `--fail-if` additionally accepts two exploitability
+predicates:
+
+| Predicate | Exits non-zero when |
+|-----------|---------------------|
+| `exploit.viable` | any technique is reported at the `VIABLE` tier |
+| `exploit.technique=<id>` | technique `<id>` is at tier `REQUIRES-LEAK` or higher |
+
+```bash
+# Fail the build if any attack technique is unobstructed by the binary's mitigations
+checksec file ./myapp --exploit --fail-if=exploit.viable
+
+# Fail specifically if a GOT-overwrite path is open
+checksec file ./myapp --exploit --fail-if=exploit.technique=got-overwrite
+```
+
+Valid technique ids are `stack-bof-overwrite`, `ret2plt`, `ret2libc`,
+`got-overwrite`, `shellcode-injection`, `format-string`, and `ret2dlresolve`
+(see the [Exploitability reference](checks/exploitability.md)).

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -23,7 +23,7 @@ These persistent flags apply to every command:
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `-o, --output <format>` | `table` | Output format: `table`, `json`, `yaml`, `xml`, `csv`. |
+| `-o, --output <format>` | `table` | Output format: `table`, `json`, `yaml`, `xml`, `csv`, `llm`. |
 | `-l, --libc <path>` | _(auto)_ | Path to libc, used by the FORTIFY check for offline / embedded filesystems. See [Advanced](advanced.md). |
 | `--color <mode>` | `auto` | Color output: `auto`, `always`, `never`. |
 | `--no-banner` | off | Suppress the ASCII banner. |
@@ -104,6 +104,11 @@ The same scan rendered in each format (columns trimmed for space):
           value: Unknown
           status: yellow
     ```
+
+=== "llm"
+
+    Self-grounding Markdown report for pasting into LLM assistants (Claude, ChatGPT, …).
+    See [LLM output](llm.md) for full documentation.
 
 !!! tip "Machine-readable output carries the color too"
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,6 +60,7 @@ nav:
   - Home: index.md
   - Usage: usage.md
   - Understanding output: output.md
+  - LLM output: llm.md
   - Checks:
       - Binary hardening: checks/binary.md
       - Exploitability: checks/exploitability.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,6 +62,7 @@ nav:
   - Understanding output: output.md
   - Checks:
       - Binary hardening: checks/binary.md
+      - Exploitability: checks/exploitability.md
       - FORTIFY: checks/fortify.md
       - Process: checks/process.md
       - Kernel: checks/kernel.md

--- a/pkg/exploit/collector_assemble_test.go
+++ b/pkg/exploit/collector_assemble_test.go
@@ -1,0 +1,30 @@
+// pkg/exploit/collector_assemble_test.go
+package exploit
+
+import (
+	"testing"
+
+	"github.com/slimm609/checksec/v3/pkg/checksec"
+)
+
+func TestPostureFromChecks(t *testing.T) {
+	checks := map[string]checksec.Result{
+		"relro":  {Value: "Partial RELRO", Status: checksec.StatusWarn},
+		"canary": {Value: "No canary", Status: checksec.StatusBad},
+		"nx":     {Value: "NX enabled", Status: checksec.StatusGood},
+		"pie":    {Value: "No PIE", Status: checksec.StatusBad},
+	}
+	e := postureFromChecks(checks)
+	if e.RELRO != RelroPartial {
+		t.Errorf("RELRO = %v, want Partial", e.RELRO)
+	}
+	if e.Canary != CanaryAbsent {
+		t.Errorf("Canary = %v, want Absent", e.Canary)
+	}
+	if !e.NX {
+		t.Error("NX should be true")
+	}
+	if e.PIE {
+		t.Error("PIE should be false")
+	}
+}

--- a/pkg/exploit/collector_static.go
+++ b/pkg/exploit/collector_static.go
@@ -1,7 +1,11 @@
 // pkg/exploit/collector_static.go
 package exploit
 
-import "debug/elf"
+import (
+	"debug/elf"
+
+	"github.com/slimm609/checksec/v3/pkg/checksec"
+)
 
 func collectImports(f *elf.File) []Import {
 	syms, err := f.ImportedSymbols()
@@ -69,4 +73,40 @@ func collectGOT(f *elf.File, relro RelroLevel) []GOTEntry {
 		}
 	}
 	return out
+}
+
+// postureFromChecks derives mitigation posture from already-computed check
+// results, keying on Status (tri-state) where possible for robustness.
+func postureFromChecks(checks map[string]checksec.Result) Evidence {
+	var e Evidence
+	switch checks["relro"].Status {
+	case checksec.StatusGood:
+		e.RELRO = RelroFull
+	case checksec.StatusWarn:
+		e.RELRO = RelroPartial
+	default:
+		e.RELRO = RelroNone
+	}
+	if checks["canary"].Status == checksec.StatusGood {
+		e.Canary = CanaryPresent
+	} else {
+		e.Canary = CanaryAbsent
+	}
+	e.NX = checks["nx"].Status == checksec.StatusGood
+	e.PIE = checks["pie"].Status == checksec.StatusGood
+	e.LazyBinding = e.RELRO != RelroFull
+	return e
+}
+
+// Collect assembles full Phase-A evidence from the parsed ELF and its checks.
+func Collect(f *elf.File, checks map[string]checksec.Result) Evidence {
+	e := postureFromChecks(checks)
+	segs, rwx := collectSegments(f)
+	e.Segments = segs
+	e.HasRWX = rwx
+	e.Imports = collectImports(f)
+	e.GOTEntries = collectGOT(f, e.RELRO)
+	e.Dynamic = f.Type == elf.ET_DYN || f.Section(".interp") != nil
+	e.Populated = FieldPosture | FieldImports | FieldGOT | FieldSegments
+	return e
 }

--- a/pkg/exploit/collector_static.go
+++ b/pkg/exploit/collector_static.go
@@ -1,0 +1,72 @@
+// pkg/exploit/collector_static.go
+package exploit
+
+import "debug/elf"
+
+func collectImports(f *elf.File) []Import {
+	syms, err := f.ImportedSymbols()
+	if err != nil {
+		return nil
+	}
+	out := make([]Import, 0, len(syms))
+	for _, s := range syms {
+		out = append(out, Import{
+			Name:     s.Name,
+			Category: Categorize(s.Name),
+			HasPLT:   true, // dynamically imported functions resolve through the PLT
+			Unsafe:   UnconditionallyUnsafe(s.Name),
+		})
+	}
+	return out
+}
+
+func collectSegments(f *elf.File) ([]Segment, bool) {
+	var segs []Segment
+	rwx := false
+	for _, p := range f.Progs {
+		if p.Type != elf.PT_LOAD {
+			continue
+		}
+		s := Segment{
+			Read:  p.Flags&elf.PF_R != 0,
+			Write: p.Flags&elf.PF_W != 0,
+			Exec:  p.Flags&elf.PF_X != 0,
+		}
+		if s.Write && s.Exec {
+			rwx = true
+		}
+		segs = append(segs, s)
+	}
+	return segs, rwx
+}
+
+// collectGOT enumerates lazily-bound PLT targets (JUMP_SLOT relocations) and
+// marks them writable when RELRO is not Full (Phase-A heuristic: Full RELRO
+// maps .got.plt read-only via BIND_NOW).
+func collectGOT(f *elf.File, relro RelroLevel) []GOTEntry {
+	rela := f.Section(".rela.plt")
+	if rela == nil {
+		return nil
+	}
+	data, err := rela.Data()
+	if err != nil {
+		return nil
+	}
+	dynsyms, err := f.DynamicSymbols()
+	if err != nil {
+		return nil
+	}
+	writable := relro != RelroFull
+	var out []GOTEntry
+	if f.Class == elf.ELFCLASS64 {
+		const entSize = 24 // Elf64_Rela: r_offset(8) r_info(8) r_addend(8)
+		for off := 0; off+entSize <= len(data); off += entSize {
+			info := f.ByteOrder.Uint64(data[off+8 : off+16])
+			symIdx := int(info >> 32)
+			if symIdx >= 1 && symIdx-1 < len(dynsyms) {
+				out = append(out, GOTEntry{Name: dynsyms[symIdx-1].Name, Writable: writable})
+			}
+		}
+	}
+	return out
+}

--- a/pkg/exploit/collector_static.go
+++ b/pkg/exploit/collector_static.go
@@ -77,6 +77,14 @@ func collectGOT(f *elf.File, relro RelroLevel) []GOTEntry {
 
 // postureFromChecks derives mitigation posture from already-computed check
 // results, keying on Status (tri-state) where possible for robustness.
+// postureFromChecks derives mitigation posture from already-computed check
+// results. A mitigation counts as ABSENT only when its check explicitly reports
+// it bad (StatusBad). Indeterminate posture — StatusWarn/StatusNA/StatusInfo,
+// e.g. NX "No GNU_STACK" (Warn), PIE "DSO" (Info) — is treated as PRESENT so the
+// reasoner never emits a VIABLE verdict from uncertain evidence (the "never
+// over-claim" honesty invariant). RELRO keeps its tri-state, mapping only an
+// explicit StatusBad to None and anything indeterminate to the most protective
+// Full.
 func postureFromChecks(checks map[string]checksec.Result) Evidence {
 	var e Evidence
 	switch checks["relro"].Status {
@@ -84,16 +92,17 @@ func postureFromChecks(checks map[string]checksec.Result) Evidence {
 		e.RELRO = RelroFull
 	case checksec.StatusWarn:
 		e.RELRO = RelroPartial
-	default:
+	case checksec.StatusBad:
 		e.RELRO = RelroNone
+	default: // indeterminate (N/A, info, error) → assume most protective
+		e.RELRO = RelroFull
 	}
-	if checks["canary"].Status == checksec.StatusGood {
-		e.Canary = CanaryPresent
-	} else {
+	e.Canary = CanaryPresent
+	if checks["canary"].Status == checksec.StatusBad {
 		e.Canary = CanaryAbsent
 	}
-	e.NX = checks["nx"].Status == checksec.StatusGood
-	e.PIE = checks["pie"].Status == checksec.StatusGood
+	e.NX = checks["nx"].Status != checksec.StatusBad
+	e.PIE = checks["pie"].Status != checksec.StatusBad
 	e.LazyBinding = e.RELRO != RelroFull
 	return e
 }

--- a/pkg/exploit/collector_static_test.go
+++ b/pkg/exploit/collector_static_test.go
@@ -1,0 +1,51 @@
+// pkg/exploit/collector_static_test.go
+package exploit
+
+import (
+	"debug/elf"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// firstELF opens the first parseable ELF under tests/binaries for structural tests.
+func firstELF(t *testing.T) *elf.File {
+	t.Helper()
+	root := filepath.Join("..", "..", "tests", "binaries")
+	var found *elf.File
+	_ = filepath.Walk(root, func(p string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() || found != nil {
+			return nil
+		}
+		f, err := elf.Open(p)
+		if err != nil {
+			return nil
+		}
+		found = f
+		return nil
+	})
+	if found == nil {
+		t.Skip("no ELF fixture available under tests/binaries")
+	}
+	return found
+}
+
+func TestCollectSegments(t *testing.T) {
+	f := firstELF(t)
+	defer f.Close()
+	segs, _ := collectSegments(f)
+	if len(segs) == 0 {
+		t.Fatal("expected at least one PT_LOAD segment")
+	}
+}
+
+func TestCollectGOTWritability(t *testing.T) {
+	f := firstELF(t)
+	defer f.Close()
+	full := collectGOT(f, RelroFull)
+	for _, g := range full {
+		if g.Writable {
+			t.Errorf("under Full RELRO no GOT entry should be writable: %+v", g)
+		}
+	}
+}

--- a/pkg/exploit/engine.go
+++ b/pkg/exploit/engine.go
@@ -1,0 +1,24 @@
+package exploit
+
+// Rule evaluates one attack technique against collected evidence.
+type Rule interface {
+	ID() string
+	Requires() EvidenceField
+	Evaluate(Evidence) *Verdict
+}
+
+// Evaluate runs rules whose required evidence fields are all populated. A rule
+// missing any required field abstains (never fires on absence). Returns nil
+// verdicts filtered out.
+func Evaluate(e Evidence, rules []Rule) []Verdict {
+	var out []Verdict
+	for _, r := range rules {
+		if e.Populated&r.Requires() != r.Requires() {
+			continue
+		}
+		if v := r.Evaluate(e); v != nil {
+			out = append(out, *v)
+		}
+	}
+	return out
+}

--- a/pkg/exploit/engine_test.go
+++ b/pkg/exploit/engine_test.go
@@ -1,0 +1,29 @@
+// pkg/exploit/engine_test.go
+package exploit
+
+import "testing"
+
+type fakeRule struct {
+	req EvidenceField
+	v   *Verdict
+}
+
+func (r fakeRule) ID() string                 { return "fake" }
+func (r fakeRule) Requires() EvidenceField    { return r.req }
+func (r fakeRule) Evaluate(Evidence) *Verdict { return r.v }
+
+func TestEngineAbstainsOnMissingEvidence(t *testing.T) {
+	e := Evidence{Populated: FieldPosture} // no FieldFunctions
+	rule := fakeRule{req: FieldFunctions, v: &Verdict{RuleID: "fake", Citations: []Citation{{"x", "y"}}}}
+	if out := Evaluate(e, []Rule{rule}); len(out) != 0 {
+		t.Errorf("rule requiring unpopulated field must abstain, got %+v", out)
+	}
+}
+
+func TestEngineFiresWhenEvidencePresent(t *testing.T) {
+	e := Evidence{Populated: FieldPosture | FieldImports}
+	rule := fakeRule{req: FieldImports, v: &Verdict{RuleID: "fake", Citations: []Citation{{"import", "gets"}}}}
+	if out := Evaluate(e, []Rule{rule}); len(out) != 1 {
+		t.Errorf("rule with satisfied requirements should fire, got %d", len(out))
+	}
+}

--- a/pkg/exploit/evidence.go
+++ b/pkg/exploit/evidence.go
@@ -13,18 +13,18 @@ type CanaryState int
 const (
 	CanaryAbsent CanaryState = iota
 	CanaryPresent
-	CanaryPartial
+	CanaryPartial // reserved for Phase B per-function coverage
 )
 
 type EvidenceField uint32
 
 const (
-	FieldPosture   EvidenceField = 1 << iota
+	FieldPosture EvidenceField = 1 << iota
 	FieldImports
 	FieldGOT
 	FieldSegments
-	FieldFunctions
-	FieldTaint
+	FieldFunctions // Phase B
+	FieldTaint     // Phase C
 )
 
 type Import struct {
@@ -46,18 +46,18 @@ type GOTEntry struct {
 }
 
 type Evidence struct {
-	RELRO            RelroLevel
-	Canary           CanaryState
-	NX               bool
-	PIE              bool
-	Dynamic          bool
-	SymbolsStripped  bool
-	LazyBinding      bool
-	Imports          []Import
-	GOTEntries       []GOTEntry
-	Segments         []Segment
-	HasRWX           bool
-	Populated        EvidenceField
+	RELRO           RelroLevel
+	Canary          CanaryState
+	NX              bool
+	PIE             bool
+	Dynamic         bool
+	SymbolsStripped bool
+	LazyBinding     bool
+	Imports         []Import
+	GOTEntries      []GOTEntry
+	Segments        []Segment
+	HasRWX          bool
+	Populated       EvidenceField
 }
 
 func (e Evidence) importsInCategory(c ImportCategory) []Import {
@@ -79,12 +79,8 @@ func (e Evidence) firstImportInCategory(c ImportCategory) *Import {
 	return nil
 }
 
+// hasControlFlowHijackPrimitive is true when the binary imports any unbounded
+// copy function — the Phase-A proxy for "a stack overflow primitive exists".
 func (e Evidence) hasControlFlowHijackPrimitive() bool {
-	if len(e.importsInCategory(CatUnboundedCopy)) > 0 {
-		return true
-	}
-	if len(e.importsInCategory(CatCommandExec)) > 0 {
-		return true
-	}
-	return false
+	return len(e.importsInCategory(CatUnboundedCopy)) > 0
 }

--- a/pkg/exploit/evidence.go
+++ b/pkg/exploit/evidence.go
@@ -1,0 +1,90 @@
+package exploit
+
+type RelroLevel int
+
+const (
+	RelroNone RelroLevel = iota
+	RelroPartial
+	RelroFull
+)
+
+type CanaryState int
+
+const (
+	CanaryAbsent CanaryState = iota
+	CanaryPresent
+	CanaryPartial
+)
+
+type EvidenceField uint32
+
+const (
+	FieldPosture   EvidenceField = 1 << iota
+	FieldImports
+	FieldGOT
+	FieldSegments
+	FieldFunctions
+	FieldTaint
+)
+
+type Import struct {
+	Name     string
+	Category ImportCategory
+	HasPLT   bool
+	Unsafe   bool
+}
+
+type Segment struct {
+	Read  bool
+	Write bool
+	Exec  bool
+}
+
+type GOTEntry struct {
+	Name     string
+	Writable bool
+}
+
+type Evidence struct {
+	RELRO            RelroLevel
+	Canary           CanaryState
+	NX               bool
+	PIE              bool
+	Dynamic          bool
+	SymbolsStripped  bool
+	LazyBinding      bool
+	Imports          []Import
+	GOTEntries       []GOTEntry
+	Segments         []Segment
+	HasRWX           bool
+	Populated        EvidenceField
+}
+
+func (e Evidence) importsInCategory(c ImportCategory) []Import {
+	var result []Import
+	for _, imp := range e.Imports {
+		if imp.Category == c {
+			result = append(result, imp)
+		}
+	}
+	return result
+}
+
+func (e Evidence) firstImportInCategory(c ImportCategory) *Import {
+	for i, imp := range e.Imports {
+		if imp.Category == c {
+			return &e.Imports[i]
+		}
+	}
+	return nil
+}
+
+func (e Evidence) hasControlFlowHijackPrimitive() bool {
+	if len(e.importsInCategory(CatUnboundedCopy)) > 0 {
+		return true
+	}
+	if len(e.importsInCategory(CatCommandExec)) > 0 {
+		return true
+	}
+	return false
+}

--- a/pkg/exploit/imports.go
+++ b/pkg/exploit/imports.go
@@ -1,0 +1,41 @@
+// pkg/exploit/imports.go
+package exploit
+
+type ImportCategory int
+
+const (
+	CatUncategorized ImportCategory = iota
+	CatUnboundedCopy
+	CatFormatSink
+	CatCommandExec
+	CatMemPerm
+	CatDynLoad
+	CatInputSource
+)
+
+var categoryTable = map[string]ImportCategory{
+	"gets": CatUnboundedCopy, "strcpy": CatUnboundedCopy, "strcat": CatUnboundedCopy,
+	"sprintf": CatUnboundedCopy, "vsprintf": CatUnboundedCopy, "scanf": CatUnboundedCopy,
+	"printf": CatFormatSink, "fprintf": CatFormatSink, "snprintf": CatFormatSink,
+	"syslog": CatFormatSink,
+	"system": CatCommandExec, "execve": CatCommandExec, "execl": CatCommandExec,
+	"execlp": CatCommandExec, "popen": CatCommandExec,
+	"mprotect": CatMemPerm, "mmap": CatMemPerm,
+	"dlopen": CatDynLoad, "dlsym": CatDynLoad,
+	"read": CatInputSource, "recv": CatInputSource, "fgets": CatInputSource,
+	"fread": CatInputSource,
+}
+
+// Categorize maps an imported symbol name to its attack-relevant category.
+func Categorize(name string) ImportCategory {
+	if c, ok := categoryTable[name]; ok {
+		return c
+	}
+	return CatUncategorized
+}
+
+// UnconditionallyUnsafe reports whether a function has no safe calling
+// convention (only gets, currently) — its mere presence proves an overflow.
+func UnconditionallyUnsafe(name string) bool {
+	return name == "gets"
+}

--- a/pkg/exploit/imports_test.go
+++ b/pkg/exploit/imports_test.go
@@ -1,0 +1,30 @@
+// pkg/exploit/imports_test.go
+package exploit
+
+import "testing"
+
+func TestCategorize(t *testing.T) {
+	cases := map[string]ImportCategory{
+		"gets": CatUnboundedCopy, "strcpy": CatUnboundedCopy, "sprintf": CatUnboundedCopy,
+		"printf": CatFormatSink, "snprintf": CatFormatSink,
+		"system": CatCommandExec, "execve": CatCommandExec, "popen": CatCommandExec,
+		"mprotect": CatMemPerm, "mmap": CatMemPerm,
+		"dlopen": CatDynLoad,
+		"read":   CatInputSource, "recv": CatInputSource,
+		"malloc": CatUncategorized,
+	}
+	for name, want := range cases {
+		if got := Categorize(name); got != want {
+			t.Errorf("Categorize(%q) = %v, want %v", name, got, want)
+		}
+	}
+}
+
+func TestUnconditionallyUnsafe(t *testing.T) {
+	if !UnconditionallyUnsafe("gets") {
+		t.Error("gets must be unconditionally unsafe")
+	}
+	if UnconditionallyUnsafe("strcpy") {
+		t.Error("strcpy is conditionally unsafe, not unconditional")
+	}
+}

--- a/pkg/exploit/invariants_test.go
+++ b/pkg/exploit/invariants_test.go
@@ -1,0 +1,46 @@
+// pkg/exploit/invariants_test.go
+package exploit
+
+import "testing"
+
+func TestInvariantNoViableWithoutCitation(t *testing.T) {
+	// exhaustive small posture matrix
+	for _, relro := range []RelroLevel{RelroNone, RelroPartial, RelroFull} {
+		for _, canary := range []CanaryState{CanaryAbsent, CanaryPresent} {
+			for _, nx := range []bool{false, true} {
+				for _, pie := range []bool{false, true} {
+					e := Evidence{
+						RELRO: relro, Canary: canary, NX: nx, PIE: pie, Dynamic: true,
+						Imports:    []Import{{Name: "gets", Category: CatUnboundedCopy, Unsafe: true}, {Name: "system", Category: CatCommandExec, HasPLT: true}},
+						GOTEntries: []GOTEntry{{Name: "printf", Writable: relro != RelroFull}},
+						Populated:  FieldPosture | FieldImports | FieldGOT | FieldSegments,
+					}
+					for _, v := range Evaluate(e, DefaultRules()) {
+						if v.Tier == TierViable && len(v.Citations) == 0 {
+							t.Errorf("VIABLE without citation: rule=%s posture=%v/%v/%v/%v", v.RuleID, relro, canary, nx, pie)
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+func TestInvariantFullRelroBlocksGotOverwrite(t *testing.T) {
+	e := Evidence{RELRO: RelroFull, Populated: FieldPosture | FieldImports | FieldGOT,
+		Imports: []Import{{Name: "gets", Category: CatUnboundedCopy, Unsafe: true}}}
+	for _, v := range Evaluate(e, DefaultRules()) {
+		if v.RuleID == "got-overwrite" && v.Tier != TierBlocked {
+			t.Errorf("Full RELRO must block got-overwrite, got %v", v.Tier)
+		}
+	}
+}
+
+func TestInvariantNXBlocksShellcode(t *testing.T) {
+	e := Evidence{NX: true, Populated: FieldPosture | FieldImports | FieldSegments}
+	for _, v := range Evaluate(e, DefaultRules()) {
+		if v.RuleID == "shellcode-injection" && v.Tier != TierBlocked {
+			t.Errorf("NX on (no mprotect/RWX) must block shellcode, got %v", v.Tier)
+		}
+	}
+}

--- a/pkg/exploit/posture_indeterminate_test.go
+++ b/pkg/exploit/posture_indeterminate_test.go
@@ -1,0 +1,61 @@
+package exploit
+
+import (
+	"testing"
+
+	"github.com/slimm609/checksec/v3/pkg/checksec"
+)
+
+// Indeterminate posture must never be read as "disabled" — otherwise the
+// reasoner would emit a VIABLE verdict from uncertain evidence.
+func TestPostureConservativeOnIndeterminate(t *testing.T) {
+	e := postureFromChecks(map[string]checksec.Result{
+		"nx":    {Value: "No GNU_STACK", Status: checksec.StatusWarn},
+		"pie":   {Value: "DSO", Status: checksec.StatusInfo},
+		"relro": {Value: "N/A", Status: checksec.StatusNA},
+	})
+	if !e.NX {
+		t.Error("indeterminate NX (No GNU_STACK / Warn) must not be treated as disabled")
+	}
+	if !e.PIE {
+		t.Error("DSO (position-independent / Info) must not be treated as non-PIE")
+	}
+	if e.RELRO != RelroFull {
+		t.Errorf("indeterminate RELRO must map to Full (most protective), got %v", e.RELRO)
+	}
+}
+
+// End-to-end honesty check: an indeterminate NX must not yield a VIABLE
+// shellcode-injection verdict.
+func TestNoViableShellcodeOnIndeterminateNX(t *testing.T) {
+	e := postureFromChecks(map[string]checksec.Result{
+		"nx": {Value: "No GNU_STACK", Status: checksec.StatusWarn},
+	})
+	e.Populated = FieldPosture | FieldImports | FieldSegments
+	for _, v := range Evaluate(e, DefaultRules()) {
+		if v.RuleID == "shellcode-injection" && v.Tier == TierViable {
+			t.Errorf("indeterminate NX must not yield VIABLE shellcode-injection, got %+v", v)
+		}
+	}
+}
+
+// An explicit "NX disabled" (StatusBad) must still be read as disabled so a
+// genuinely unprotected binary still produces the VIABLE verdict.
+func TestExplicitNXDisabledStillViable(t *testing.T) {
+	e := postureFromChecks(map[string]checksec.Result{
+		"nx": {Value: "NX disabled", Status: checksec.StatusBad},
+	})
+	if e.NX {
+		t.Fatal("explicit NX disabled (StatusBad) must be read as disabled")
+	}
+	e.Populated = FieldPosture | FieldImports | FieldSegments
+	found := false
+	for _, v := range Evaluate(e, DefaultRules()) {
+		if v.RuleID == "shellcode-injection" && v.Tier == TierViable {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("explicit NX disabled must yield VIABLE shellcode-injection")
+	}
+}

--- a/pkg/exploit/rule_bar.go
+++ b/pkg/exploit/rule_bar.go
@@ -1,0 +1,32 @@
+// pkg/exploit/rule_bar.go
+package exploit
+
+import "strings"
+
+// synthesizeBar describes the overall attacker bar in one sentence.
+func synthesizeBar(e Evidence, verdicts []Verdict) string {
+	var needs []string
+	if e.PIE {
+		needs = append(needs, "an info leak (PIE)")
+	}
+	if e.Canary == CanaryPresent {
+		needs = append(needs, "a stack-canary bypass")
+	}
+	if e.RELRO == RelroFull {
+		needs = append(needs, "a non-GOT control target (Full RELRO)")
+	}
+	hasViable := false
+	for _, v := range verdicts {
+		if v.Tier == TierViable {
+			hasViable = true
+			break
+		}
+	}
+	if len(needs) == 0 && hasViable {
+		return "Attacker needs a reachable bug; no leak or bypass required."
+	}
+	if len(needs) == 0 {
+		return "No unobstructed memory-corruption technique found at static fidelity."
+	}
+	return "Attacker must obtain " + strings.Join(needs, " + ") + "."
+}

--- a/pkg/exploit/rule_formatstring.go
+++ b/pkg/exploit/rule_formatstring.go
@@ -1,0 +1,24 @@
+package exploit
+
+type formatStringRule struct{}
+
+func (formatStringRule) ID() string              { return "format-string" }
+func (formatStringRule) Requires() EvidenceField { return FieldImports }
+
+func (formatStringRule) Evaluate(e Evidence) *Verdict {
+	sinks := e.importsInCategory(CatFormatSink)
+	if len(sinks) == 0 {
+		return nil
+	}
+	var cites []Citation
+	for _, s := range sinks {
+		cites = append(cites, Citation{Kind: "import", Value: s.Name})
+	}
+	return &Verdict{
+		RuleID:      "format-string",
+		Technique:   "Format-string read/write primitive",
+		Tier:        TierRequiresInputControl,
+		Citations:   cites,
+		Assumptions: []string{"attacker controls a format argument"},
+	}
+}

--- a/pkg/exploit/rule_gotoverwrite.go
+++ b/pkg/exploit/rule_gotoverwrite.go
@@ -1,0 +1,35 @@
+package exploit
+
+type gotOverwriteRule struct{}
+
+func (gotOverwriteRule) ID() string              { return "got-overwrite" }
+func (gotOverwriteRule) Requires() EvidenceField { return FieldPosture | FieldImports | FieldGOT }
+
+func (gotOverwriteRule) Evaluate(e Evidence) *Verdict {
+	if e.RELRO == RelroFull {
+		return &Verdict{
+			RuleID:       "got-overwrite",
+			Technique:    "GOT entry overwrite",
+			Tier:         TierBlocked,
+			ObstructedBy: []string{"Full RELRO"},
+			Citations:    []Citation{{Kind: "posture", Value: "Full RELRO"}},
+		}
+	}
+	var cites []Citation
+	for _, g := range e.GOTEntries {
+		if g.Writable {
+			cites = append(cites, Citation{Kind: "got", Value: g.Name})
+		}
+	}
+	writePrimitive := e.hasControlFlowHijackPrimitive() || len(e.importsInCategory(CatFormatSink)) > 0
+	if len(cites) == 0 || !writePrimitive {
+		return nil
+	}
+	return &Verdict{
+		RuleID:      "got-overwrite",
+		Technique:   "GOT entry overwrite",
+		Tier:        TierViable,
+		Citations:   cites,
+		Assumptions: []string{"an arbitrary or relative write primitive"},
+	}
+}

--- a/pkg/exploit/rule_gotoverwrite_test.go
+++ b/pkg/exploit/rule_gotoverwrite_test.go
@@ -1,0 +1,23 @@
+package exploit
+
+import "testing"
+
+func TestGotOverwriteViablePartialRelro(t *testing.T) {
+	e := Evidence{
+		RELRO:      RelroPartial,
+		Imports:    []Import{{Name: "gets", Category: CatUnboundedCopy, Unsafe: true}},
+		GOTEntries: []GOTEntry{{Name: "printf", Writable: true}},
+	}
+	v := gotOverwriteRule{}.Evaluate(e)
+	if v == nil || v.Tier != TierViable {
+		t.Fatalf("partial RELRO + writable GOT + write primitive → VIABLE, got %+v", v)
+	}
+}
+
+func TestGotOverwriteBlockedFullRelro(t *testing.T) {
+	e := Evidence{RELRO: RelroFull, GOTEntries: []GOTEntry{{Name: "printf", Writable: false}}}
+	v := gotOverwriteRule{}.Evaluate(e)
+	if v == nil || v.Tier != TierBlocked {
+		t.Fatalf("full RELRO → BLOCKED, got %+v", v)
+	}
+}

--- a/pkg/exploit/rule_ret2dlresolve.go
+++ b/pkg/exploit/rule_ret2dlresolve.go
@@ -1,0 +1,33 @@
+package exploit
+
+type ret2dlresolveRule struct{}
+
+func (ret2dlresolveRule) ID() string              { return "ret2dlresolve" }
+func (ret2dlresolveRule) Requires() EvidenceField { return FieldPosture | FieldImports }
+
+func (ret2dlresolveRule) Evaluate(e Evidence) *Verdict {
+	if !e.Dynamic || !e.hasControlFlowHijackPrimitive() {
+		return nil
+	}
+	if e.RELRO == RelroFull {
+		return &Verdict{
+			RuleID:       "ret2dlresolve",
+			Technique:    "ret2dlresolve",
+			Tier:         TierBlocked,
+			ObstructedBy: []string{"Full RELRO (BIND_NOW)"},
+			Citations:    []Citation{{Kind: "posture", Value: "Full RELRO"}},
+		}
+	}
+	v := &Verdict{
+		RuleID:      "ret2dlresolve",
+		Technique:   "ret2dlresolve",
+		Citations:   []Citation{{Kind: "posture", Value: "lazy binding"}},
+		Assumptions: []string{"a control-flow hijack primitive is reachable"},
+	}
+	if e.PIE {
+		v.Tier = TierRequiresLeak
+	} else {
+		v.Tier = TierViable
+	}
+	return v
+}

--- a/pkg/exploit/rule_ret2dlresolve.go
+++ b/pkg/exploit/rule_ret2dlresolve.go
@@ -21,9 +21,12 @@ func (ret2dlresolveRule) Evaluate(e Evidence) *Verdict {
 	v := &Verdict{
 		RuleID:      "ret2dlresolve",
 		Technique:   "ret2dlresolve",
-		Citations:   []Citation{{Kind: "posture", Value: "lazy binding"}},
 		Assumptions: []string{"a control-flow hijack primitive is reachable"},
 	}
+	if imp := e.firstImportInCategory(CatUnboundedCopy); imp != nil {
+		v.Citations = append(v.Citations, Citation{Kind: "import", Value: imp.Name})
+	}
+	v.Citations = append(v.Citations, Citation{Kind: "posture", Value: "lazy binding"})
 	if e.PIE {
 		v.Tier = TierRequiresLeak
 	} else {

--- a/pkg/exploit/rule_ret2libc.go
+++ b/pkg/exploit/rule_ret2libc.go
@@ -1,0 +1,25 @@
+package exploit
+
+type ret2libcRule struct{}
+
+func (ret2libcRule) ID() string              { return "ret2libc" }
+func (ret2libcRule) Requires() EvidenceField { return FieldPosture | FieldImports }
+
+func (ret2libcRule) Evaluate(e Evidence) *Verdict {
+	if !e.Dynamic || !e.hasControlFlowHijackPrimitive() {
+		return nil
+	}
+	v := &Verdict{
+		RuleID:      "ret2libc",
+		Technique:   "ret2libc",
+		Citations:   []Citation{{Kind: "posture", Value: "dynamically linked"}},
+		Assumptions: []string{"a control-flow hijack primitive is reachable"},
+	}
+	if e.PIE {
+		v.Tier = TierRequiresLeak
+		v.Assumptions = append(v.Assumptions, "libc base address leak")
+	} else {
+		v.Tier = TierViable
+	}
+	return v
+}

--- a/pkg/exploit/rule_ret2libc.go
+++ b/pkg/exploit/rule_ret2libc.go
@@ -12,9 +12,12 @@ func (ret2libcRule) Evaluate(e Evidence) *Verdict {
 	v := &Verdict{
 		RuleID:      "ret2libc",
 		Technique:   "ret2libc",
-		Citations:   []Citation{{Kind: "posture", Value: "dynamically linked"}},
 		Assumptions: []string{"a control-flow hijack primitive is reachable"},
 	}
+	if imp := e.firstImportInCategory(CatUnboundedCopy); imp != nil {
+		v.Citations = append(v.Citations, Citation{Kind: "import", Value: imp.Name})
+	}
+	v.Citations = append(v.Citations, Citation{Kind: "posture", Value: "dynamically linked"})
 	if e.PIE {
 		v.Tier = TierRequiresLeak
 		v.Assumptions = append(v.Assumptions, "libc base address leak")

--- a/pkg/exploit/rule_ret2plt.go
+++ b/pkg/exploit/rule_ret2plt.go
@@ -1,0 +1,31 @@
+// pkg/exploit/rule_ret2plt.go
+package exploit
+
+type ret2pltRule struct{}
+
+func (ret2pltRule) ID() string              { return "ret2plt" }
+func (ret2pltRule) Requires() EvidenceField { return FieldPosture | FieldImports }
+
+func (ret2pltRule) Evaluate(e Evidence) *Verdict {
+	if !e.hasControlFlowHijackPrimitive() {
+		return nil
+	}
+	target := e.firstImportInCategory(CatCommandExec)
+	if target == nil || !target.HasPLT {
+		return nil
+	}
+	v := &Verdict{
+		RuleID:      "ret2plt",
+		Technique:   "ret2plt → " + target.Name,
+		Citations:   []Citation{{Kind: "import", Value: target.Name + "@plt"}},
+		Assumptions: []string{"a control-flow hijack primitive is reachable"},
+	}
+	if e.PIE {
+		v.Tier = TierRequiresLeak
+		v.Citations = append(v.Citations, Citation{Kind: "posture", Value: "PIE enabled"})
+	} else {
+		v.Tier = TierViable
+		v.Citations = append(v.Citations, Citation{Kind: "posture", Value: "PIE disabled"})
+	}
+	return v
+}

--- a/pkg/exploit/rule_ret2plt_test.go
+++ b/pkg/exploit/rule_ret2plt_test.go
@@ -1,0 +1,29 @@
+// pkg/exploit/rule_ret2plt_test.go
+package exploit
+
+import "testing"
+
+func base() Evidence {
+	return Evidence{Imports: []Import{
+		{Name: "gets", Category: CatUnboundedCopy, Unsafe: true},
+		{Name: "system", Category: CatCommandExec, HasPLT: true},
+	}}
+}
+
+func TestRet2PltViableNoPIE(t *testing.T) {
+	e := base()
+	e.PIE = false
+	v := ret2pltRule{}.Evaluate(e)
+	if v == nil || v.Tier != TierViable {
+		t.Fatalf("no PIE + system@plt + hijack → VIABLE, got %+v", v)
+	}
+}
+
+func TestRet2PltRequiresLeakWithPIE(t *testing.T) {
+	e := base()
+	e.PIE = true
+	v := ret2pltRule{}.Evaluate(e)
+	if v == nil || v.Tier != TierRequiresLeak {
+		t.Fatalf("PIE on → REQUIRES-LEAK, got %+v", v)
+	}
+}

--- a/pkg/exploit/rule_shellcode.go
+++ b/pkg/exploit/rule_shellcode.go
@@ -1,0 +1,37 @@
+package exploit
+
+type shellcodeRule struct{}
+
+func (shellcodeRule) ID() string              { return "shellcode-injection" }
+func (shellcodeRule) Requires() EvidenceField { return FieldPosture | FieldImports | FieldSegments }
+
+func (shellcodeRule) Evaluate(e Evidence) *Verdict {
+	if !e.NX || e.HasRWX {
+		cite := Citation{Kind: "posture", Value: "NX disabled"}
+		if e.HasRWX {
+			cite = Citation{Kind: "segment", Value: "RWX segment"}
+		}
+		return &Verdict{
+			RuleID:    "shellcode-injection",
+			Technique: "Shellcode injection",
+			Tier:      TierViable,
+			Citations: []Citation{cite},
+		}
+	}
+	if mp := e.firstImportInCategory(CatMemPerm); mp != nil {
+		return &Verdict{
+			RuleID:      "shellcode-injection",
+			Technique:   "Shellcode via " + mp.Name,
+			Tier:        TierEnabler,
+			Citations:   []Citation{{Kind: "import", Value: mp.Name}},
+			Assumptions: []string{"a call primitive to invoke " + mp.Name + " with PROT_EXEC"},
+		}
+	}
+	return &Verdict{
+		RuleID:       "shellcode-injection",
+		Technique:    "Shellcode injection",
+		Tier:         TierBlocked,
+		ObstructedBy: []string{"NX"},
+		Citations:    []Citation{{Kind: "posture", Value: "NX enabled"}},
+	}
+}

--- a/pkg/exploit/rule_shellcode_test.go
+++ b/pkg/exploit/rule_shellcode_test.go
@@ -1,0 +1,25 @@
+package exploit
+
+import "testing"
+
+func TestShellcodeViableNoNX(t *testing.T) {
+	v := shellcodeRule{}.Evaluate(Evidence{NX: false})
+	if v == nil || v.Tier != TierViable {
+		t.Fatalf("NX off → VIABLE, got %+v", v)
+	}
+}
+
+func TestShellcodeBlockedByNX(t *testing.T) {
+	v := shellcodeRule{}.Evaluate(Evidence{NX: true})
+	if v == nil || v.Tier != TierBlocked {
+		t.Fatalf("NX on + no mprotect + no RWX → BLOCKED, got %+v", v)
+	}
+}
+
+func TestShellcodeEnablerViaMprotect(t *testing.T) {
+	e := Evidence{NX: true, Imports: []Import{{Name: "mprotect", Category: CatMemPerm}}}
+	v := shellcodeRule{}.Evaluate(e)
+	if v == nil || v.Tier != TierEnabler {
+		t.Fatalf("mprotect present → ENABLER, got %+v", v)
+	}
+}

--- a/pkg/exploit/rule_stackbof.go
+++ b/pkg/exploit/rule_stackbof.go
@@ -1,0 +1,44 @@
+// pkg/exploit/rule_stackbof.go
+package exploit
+
+// stackBOFRule detects a stack-based buffer overflow write primitive via an
+// unbounded copy into a stack buffer.
+type stackBOFRule struct{}
+
+func (stackBOFRule) ID() string { return "stack-bof-overwrite" }
+
+func (stackBOFRule) Requires() EvidenceField { return FieldPosture | FieldImports }
+
+func (stackBOFRule) Evaluate(e Evidence) *Verdict {
+	copies := e.importsInCategory(CatUnboundedCopy)
+	if len(copies) == 0 {
+		return nil
+	}
+
+	unsafe := false
+	citations := make([]Citation, 0, len(copies))
+	for _, imp := range copies {
+		citations = append(citations, Citation{Kind: "import", Value: imp.Name})
+		if imp.Unsafe {
+			unsafe = true
+		}
+	}
+
+	v := &Verdict{
+		RuleID:      "stack-bof-overwrite",
+		Technique:   "stack-based buffer overflow via an unbounded copy",
+		Citations:   citations,
+		Assumptions: []string{"attacker controls input reaching an unbounded copy"},
+	}
+
+	switch {
+	case e.Canary == CanaryPresent:
+		v.Tier = TierBlocked
+		v.ObstructedBy = []string{"stack canary"}
+	case unsafe:
+		v.Tier = TierViable
+	default:
+		v.Tier = TierLikely
+	}
+	return v
+}

--- a/pkg/exploit/rule_stackbof_test.go
+++ b/pkg/exploit/rule_stackbof_test.go
@@ -1,0 +1,33 @@
+// pkg/exploit/rule_stackbof_test.go
+package exploit
+
+import "testing"
+
+func TestStackBOFViableWithGets(t *testing.T) {
+	e := Evidence{
+		Canary:  CanaryAbsent,
+		Imports: []Import{{Name: "gets", Category: CatUnboundedCopy, Unsafe: true}},
+	}
+	v := stackBOFRule{}.Evaluate(e)
+	if v == nil || v.Tier != TierViable {
+		t.Fatalf("gets + no canary must be VIABLE, got %+v", v)
+	}
+	if len(v.Citations) == 0 {
+		t.Error("verdict must cite evidence")
+	}
+}
+
+func TestStackBOFBlockedByCanary(t *testing.T) {
+	e := Evidence{Canary: CanaryPresent, Imports: []Import{{Name: "gets", Category: CatUnboundedCopy, Unsafe: true}}}
+	v := stackBOFRule{}.Evaluate(e)
+	if v == nil || v.Tier != TierBlocked {
+		t.Fatalf("canary present must BLOCK, got %+v", v)
+	}
+}
+
+func TestStackBOFNilWithoutCopy(t *testing.T) {
+	r := stackBOFRule{}
+	if r.Evaluate(Evidence{Canary: CanaryAbsent}) != nil {
+		t.Error("no unbounded-copy import → rule does not apply (nil)")
+	}
+}

--- a/pkg/exploit/rules.go
+++ b/pkg/exploit/rules.go
@@ -1,0 +1,29 @@
+// pkg/exploit/rules.go
+package exploit
+
+import (
+	"debug/elf"
+
+	"github.com/slimm609/checksec/v3/pkg/checksec"
+)
+
+// Report is the exploitability result for one binary.
+type Report struct {
+	Verdicts []Verdict `json:"verdicts" yaml:"verdicts"`
+	Bar      string    `json:"bar"      yaml:"bar"`
+}
+
+// DefaultRules is the Phase-A rule corpus (core four first, then secondary).
+func DefaultRules() []Rule {
+	return []Rule{
+		stackBOFRule{}, ret2pltRule{}, gotOverwriteRule{}, shellcodeRule{},
+		ret2libcRule{}, formatStringRule{}, ret2dlresolveRule{},
+	}
+}
+
+// Assess collects evidence, evaluates the corpus, and synthesizes the bar line.
+func Assess(f *elf.File, checks map[string]checksec.Result) Report {
+	e := Collect(f, checks)
+	verdicts := Evaluate(e, DefaultRules())
+	return Report{Verdicts: verdicts, Bar: synthesizeBar(e, verdicts)}
+}

--- a/pkg/exploit/rules.go
+++ b/pkg/exploit/rules.go
@@ -21,6 +21,18 @@ func DefaultRules() []Rule {
 	}
 }
 
+// IsKnownRuleID reports whether id names a technique in the default corpus. It
+// lets consumers (e.g. --fail-if exploit.technique=<id>) reject typos and empty
+// ids instead of silently accepting a predicate that can never match.
+func IsKnownRuleID(id string) bool {
+	for _, r := range DefaultRules() {
+		if r.ID() == id {
+			return true
+		}
+	}
+	return false
+}
+
 // Assess collects evidence, evaluates the corpus, and synthesizes the bar line.
 func Assess(f *elf.File, checks map[string]checksec.Result) Report {
 	e := Collect(f, checks)

--- a/pkg/exploit/rules_secondary_test.go
+++ b/pkg/exploit/rules_secondary_test.go
@@ -1,0 +1,28 @@
+package exploit
+
+import "testing"
+
+func TestRet2LibcRequiresLeakWithPIE(t *testing.T) {
+	e := Evidence{Dynamic: true, PIE: true, Imports: []Import{{Name: "gets", Category: CatUnboundedCopy, Unsafe: true}}}
+	v := ret2libcRule{}.Evaluate(e)
+	if v == nil || v.Tier != TierRequiresLeak {
+		t.Fatalf("dynamic + PIE → REQUIRES-LEAK, got %+v", v)
+	}
+}
+
+func TestFormatStringRequiresInputControl(t *testing.T) {
+	e := Evidence{Imports: []Import{{Name: "printf", Category: CatFormatSink}}}
+	v := formatStringRule{}.Evaluate(e)
+	if v == nil || v.Tier != TierRequiresInputControl {
+		t.Fatalf("printf import → REQUIRES-INPUT-CONTROL, got %+v", v)
+	}
+}
+
+func TestRet2DlresolveBlockedFullRelro(t *testing.T) {
+	e := Evidence{Dynamic: true, LazyBinding: false, RELRO: RelroFull,
+		Imports: []Import{{Name: "gets", Category: CatUnboundedCopy, Unsafe: true}}}
+	v := ret2dlresolveRule{}.Evaluate(e)
+	if v == nil || v.Tier != TierBlocked {
+		t.Fatalf("full RELRO (BIND_NOW) → BLOCKED, got %+v", v)
+	}
+}

--- a/pkg/exploit/rules_secondary_test.go
+++ b/pkg/exploit/rules_secondary_test.go
@@ -26,3 +26,38 @@ func TestRet2DlresolveBlockedFullRelro(t *testing.T) {
 		t.Fatalf("full RELRO (BIND_NOW) → BLOCKED, got %+v", v)
 	}
 }
+
+func TestRet2LibcCitesGatingImport(t *testing.T) {
+	e := Evidence{Dynamic: true, PIE: false, Imports: []Import{{Name: "gets", Category: CatUnboundedCopy, Unsafe: true}}}
+	v := ret2libcRule{}.Evaluate(e)
+	if v == nil {
+		t.Fatalf("expected verdict, got nil")
+	}
+	found := false
+	for _, c := range v.Citations {
+		if c.Kind == "import" && c.Value == "gets" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected an import citation for the gating primitive (gets), got %+v", v.Citations)
+	}
+}
+
+func TestRet2DlresolveCitesGatingImport(t *testing.T) {
+	e := Evidence{Dynamic: true, LazyBinding: true, RELRO: RelroNone, PIE: false,
+		Imports: []Import{{Name: "gets", Category: CatUnboundedCopy, Unsafe: true}}}
+	v := ret2dlresolveRule{}.Evaluate(e)
+	if v == nil {
+		t.Fatalf("expected verdict, got nil")
+	}
+	found := false
+	for _, c := range v.Citations {
+		if c.Kind == "import" && c.Value == "gets" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected an import citation for the gating primitive (gets), got %+v", v.Citations)
+	}
+}

--- a/pkg/exploit/rules_test.go
+++ b/pkg/exploit/rules_test.go
@@ -1,0 +1,30 @@
+// pkg/exploit/rules_test.go
+package exploit
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/slimm609/checksec/v3/pkg/checksec"
+)
+
+func TestAssessProducesVerdictsAndBar(t *testing.T) {
+	f := firstELF(t)
+	defer f.Close()
+	checks := map[string]checksec.Result{
+		"relro":  {Status: checksec.StatusWarn},
+		"canary": {Status: checksec.StatusBad},
+		"nx":     {Status: checksec.StatusGood},
+		"pie":    {Status: checksec.StatusBad},
+	}
+	rep := Assess(f, checks)
+	if rep.Bar == "" {
+		t.Error("Bar synthesis line must be non-empty")
+	}
+	for _, v := range rep.Verdicts {
+		if len(v.Citations) == 0 {
+			t.Errorf("verdict %s has no citations (honesty invariant)", v.RuleID)
+		}
+	}
+	_ = strings.TrimSpace(rep.Bar)
+}

--- a/pkg/exploit/verdict.go
+++ b/pkg/exploit/verdict.go
@@ -30,6 +30,9 @@ func (t Tier) String() string {
 	}
 }
 
+// MarshalText makes Tier serialize as its name in JSON/YAML.
+func (t Tier) MarshalText() ([]byte, error) { return []byte(t.String()), nil }
+
 type Citation struct {
 	Kind  string // "import" | "segment" | "got" | "posture"
 	Value string

--- a/pkg/exploit/verdict.go
+++ b/pkg/exploit/verdict.go
@@ -18,9 +18,9 @@ func (t Tier) String() string {
 	case TierEnabler:
 		return "ENABLER"
 	case TierRequiresInputControl:
-		return "REQUIRES_INPUT_CONTROL"
+		return "REQUIRES-INPUT-CONTROL"
 	case TierRequiresLeak:
-		return "REQUIRES_LEAK"
+		return "REQUIRES-LEAK"
 	case TierLikely:
 		return "LIKELY"
 	case TierViable:
@@ -36,10 +36,10 @@ type Citation struct {
 }
 
 type Verdict struct {
-	RuleID      string
-	Technique   string
-	Tier        Tier
-	Citations   []Citation
-	Assumptions []string
+	RuleID       string
+	Technique    string
+	Tier         Tier
+	Citations    []Citation
+	Assumptions  []string
 	ObstructedBy []string
 }

--- a/pkg/exploit/verdict.go
+++ b/pkg/exploit/verdict.go
@@ -1,0 +1,45 @@
+package exploit
+
+type Tier int
+
+const (
+	TierBlocked Tier = iota
+	TierEnabler
+	TierRequiresInputControl
+	TierRequiresLeak
+	TierLikely
+	TierViable
+)
+
+func (t Tier) String() string {
+	switch t {
+	case TierBlocked:
+		return "BLOCKED"
+	case TierEnabler:
+		return "ENABLER"
+	case TierRequiresInputControl:
+		return "REQUIRES_INPUT_CONTROL"
+	case TierRequiresLeak:
+		return "REQUIRES_LEAK"
+	case TierLikely:
+		return "LIKELY"
+	case TierViable:
+		return "VIABLE"
+	default:
+		return "UNKNOWN"
+	}
+}
+
+type Citation struct {
+	Kind  string // "import" | "segment" | "got" | "posture"
+	Value string
+}
+
+type Verdict struct {
+	RuleID      string
+	Technique   string
+	Tier        Tier
+	Citations   []Citation
+	Assumptions []string
+	ObstructedBy []string
+}

--- a/pkg/exploit/verdict_test.go
+++ b/pkg/exploit/verdict_test.go
@@ -1,0 +1,28 @@
+package exploit
+
+import "testing"
+
+func TestTierString(t *testing.T) {
+	if TierViable.String() != "VIABLE" {
+		t.Errorf("got %q", TierViable.String())
+	}
+	if TierBlocked.String() != "BLOCKED" {
+		t.Errorf("got %q", TierBlocked.String())
+	}
+}
+
+func TestEvidenceHelpers(t *testing.T) {
+	e := Evidence{Imports: []Import{
+		{Name: "gets", Category: CatUnboundedCopy, Unsafe: true},
+		{Name: "system", Category: CatCommandExec},
+	}}
+	if got := e.importsInCategory(CatUnboundedCopy); len(got) != 1 || got[0].Name != "gets" {
+		t.Errorf("importsInCategory = %+v", got)
+	}
+	if e.firstImportInCategory(CatCommandExec).Name != "system" {
+		t.Error("firstImportInCategory(CommandExec) should be system")
+	}
+	if !e.hasControlFlowHijackPrimitive() {
+		t.Error("unbounded copy import should count as a hijack primitive")
+	}
+}

--- a/pkg/exploit/verdict_test.go
+++ b/pkg/exploit/verdict_test.go
@@ -1,6 +1,9 @@
 package exploit
 
-import "testing"
+import (
+	"encoding/json"
+	"testing"
+)
 
 func TestTierString(t *testing.T) {
 	if TierViable.String() != "VIABLE" {
@@ -8,6 +11,16 @@ func TestTierString(t *testing.T) {
 	}
 	if TierBlocked.String() != "BLOCKED" {
 		t.Errorf("got %q", TierBlocked.String())
+	}
+}
+
+func TestTierMarshalText(t *testing.T) {
+	b, err := json.Marshal(TierBlocked)
+	if err != nil {
+		t.Fatalf("Marshal error: %v", err)
+	}
+	if string(b) != `"BLOCKED"` {
+		t.Errorf("got %s, want %q", b, `"BLOCKED"`)
 	}
 }
 

--- a/pkg/knowledge/knowledge.go
+++ b/pkg/knowledge/knowledge.go
@@ -1,0 +1,53 @@
+package knowledge
+
+// Check is the machine-readable ground truth for one checksec check.
+type Check struct {
+	ID          string   `json:"id"`
+	Name        string   `json:"name"`
+	Meaning     string   `json:"meaning"`
+	Remediation string   `json:"remediation,omitempty"`
+	Refs        []string `json:"refs,omitempty"`
+}
+
+// registry MUST cover every id in utils.FileFields (enforced by a test in
+// package utils, which can import both without a cycle).
+var registry = map[string]Check{
+	"relro":          {ID: "relro", Name: "RELRO", Meaning: "GOT/data write protection.", Remediation: "link `-Wl,-z,relro,-z,now`"},
+	"canary":         {ID: "canary", Name: "Stack Canary", Meaning: "Stack-smashing guard.", Remediation: "compile `-fstack-protector-strong`"},
+	"cfi":            {ID: "cfi", Name: "CFI", Meaning: "Control-flow integrity for indirect calls.", Remediation: "build with `-fcf-protection` / `-fsanitize=cfi`"},
+	"nx":             {ID: "nx", Name: "NX", Meaning: "Non-executable stack/heap."},
+	"pie":            {ID: "pie", Name: "PIE", Meaning: "Position independence → ASLR for the executable.", Remediation: "`-fPIE -pie`"},
+	"rpath":          {ID: "rpath", Name: "RPATH", Meaning: "Hard-coded library search path (hijack risk).", Remediation: "remove `-Wl,-rpath`"},
+	"runpath":        {ID: "runpath", Name: "RUNPATH", Meaning: "Library search path (hijack risk).", Remediation: "remove `-Wl,-rpath` / audit RUNPATH"},
+	"symbols":        {ID: "symbols", Name: "Symbols", Meaning: "Symbol table presence (aids reversing).", Remediation: "`strip` for release builds"},
+	"safestack":      {ID: "safestack", Name: "SafeStack", Meaning: "Separate unsafe stack for buffers.", Remediation: "`-fsanitize=safe-stack`"},
+	"stack_clash":    {ID: "stack_clash", Name: "Stack Clash", Meaning: "Stack-clash probing in prologues.", Remediation: "`-fstack-clash-protection`"},
+	"separate_code":  {ID: "separate_code", Name: "W^X Seg", Meaning: "No writable+executable segment.", Remediation: "avoid RWX segments / `-Wl,-z,separate-code`"},
+	"selfrando":      {ID: "selfrando", Name: "Selfrando", Meaning: "Function-level load randomization."},
+	"sanitizers":     {ID: "sanitizers", Name: "Sanitizers", Meaning: "ASan/UBSan instrumentation present."},
+	"fortify_level":  {ID: "fortify_level", Name: "FORTIFY Lvl", Meaning: "_FORTIFY_SOURCE level.", Remediation: "`-D_FORTIFY_SOURCE=3 -O2`"},
+	"glibcxx_assert": {ID: "glibcxx_assert", Name: "GLIBCXX Assert", Meaning: "libstdc++ hardening assertions.", Remediation: "`-D_GLIBCXX_ASSERTIONS`"},
+	"fortify_source": {ID: "fortify_source", Name: "FORTIFY", Meaning: "Fortified libc call substitution.", Remediation: "`-D_FORTIFY_SOURCE=2 -O2`"},
+	"fortified":      {ID: "fortified", Name: "Fortified", Meaning: "Count of fortified call sites."},
+	"fortifyable":    {ID: "fortifyable", Name: "Fortifiable", Meaning: "Count of fortifiable call sites."},
+	"seccomp":        {ID: "seccomp", Name: "Seccomp", Meaning: "Process seccomp-bpf syscall filtering (proc mode)."},
+}
+
+func Lookup(id string) (Check, bool) {
+	c, ok := registry[id]
+	return c, ok
+}
+
+// Present returns knowledge for the given ids in order, with a fallback entry
+// for any id lacking a registry record.
+func Present(ids []string) []Check {
+	out := make([]Check, 0, len(ids))
+	for _, id := range ids {
+		if c, ok := registry[id]; ok {
+			out = append(out, c)
+		} else {
+			out = append(out, Check{ID: id, Name: id, Meaning: "(no description available)"})
+		}
+	}
+	return out
+}

--- a/pkg/knowledge/knowledge_test.go
+++ b/pkg/knowledge/knowledge_test.go
@@ -1,0 +1,26 @@
+package knowledge
+
+import "testing"
+
+func TestLookupKnownCheck(t *testing.T) {
+	c, ok := Lookup("relro")
+	if !ok {
+		t.Fatal("relro must be in the registry")
+	}
+	if c.Remediation == "" {
+		t.Error("relro must carry a remediation")
+	}
+}
+
+func TestPresentPreservesOrderAndFallsBack(t *testing.T) {
+	got := Present([]string{"pie", "definitely-not-a-check"})
+	if len(got) != 2 {
+		t.Fatalf("want 2 entries, got %d", len(got))
+	}
+	if got[0].ID != "pie" {
+		t.Errorf("order not preserved: %+v", got)
+	}
+	if got[1].Meaning != "(no description available)" {
+		t.Errorf("unknown id must fall back, got %q", got[1].Meaning)
+	}
+}

--- a/pkg/utils/chainPrinter.go
+++ b/pkg/utils/chainPrinter.go
@@ -1,0 +1,43 @@
+package utils
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/slimm609/checksec/v3/pkg/exploit"
+)
+
+// RenderChain emits a labeled hypothesis chain: a VIABLE control-flow-hijack
+// step plus a mutually-consistent VIABLE payload step. Never presented as fact.
+func RenderChain(w io.Writer, r *exploit.Report) {
+	if r == nil {
+		return
+	}
+	hijack := findVerdict(r, "stack-bof-overwrite", exploit.TierViable)
+	payload := firstViablePayload(r)
+	if hijack == nil || payload == nil {
+		fmt.Fprintln(w, "Suggested chain: no consistent chain at current tier.")
+		return
+	}
+	fmt.Fprintln(w, "Suggested chain (hypothesis):")
+	fmt.Fprintf(w, "  1. %s [%s: %s]\n", hijack.Technique, hijack.RuleID, hijack.Tier)
+	fmt.Fprintf(w, "  2. %s [%s: %s]\n", payload.Technique, payload.RuleID, payload.Tier)
+}
+
+func findVerdict(r *exploit.Report, id string, tier exploit.Tier) *exploit.Verdict {
+	for i := range r.Verdicts {
+		if r.Verdicts[i].RuleID == id && r.Verdicts[i].Tier == tier {
+			return &r.Verdicts[i]
+		}
+	}
+	return nil
+}
+
+func firstViablePayload(r *exploit.Report) *exploit.Verdict {
+	for _, id := range []string{"ret2plt", "got-overwrite", "shellcode-injection", "ret2libc"} {
+		if v := findVerdict(r, id, exploit.TierViable); v != nil {
+			return v
+		}
+	}
+	return nil
+}

--- a/pkg/utils/chainPrinter_test.go
+++ b/pkg/utils/chainPrinter_test.go
@@ -1,0 +1,38 @@
+package utils
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/slimm609/checksec/v3/pkg/exploit"
+)
+
+func TestRenderChainHypothesis(t *testing.T) {
+	r := &exploit.Report{Verdicts: []exploit.Verdict{
+		{RuleID: "stack-bof-overwrite", Tier: exploit.TierViable, Technique: "Stack overflow",
+			Citations: []exploit.Citation{{Kind: "import", Value: "gets"}}},
+		{RuleID: "ret2plt", Tier: exploit.TierViable, Technique: "ret2plt → system",
+			Citations: []exploit.Citation{{Kind: "import", Value: "system@plt"}}},
+	}}
+	var buf bytes.Buffer
+	RenderChain(&buf, r)
+	out := buf.String()
+	if !strings.Contains(strings.ToLower(out), "hypothesis") {
+		t.Errorf("chain must be labeled hypothesis:\n%s", out)
+	}
+	if !strings.Contains(out, "stack-bof-overwrite") || !strings.Contains(out, "ret2plt") {
+		t.Errorf("chain missing steps:\n%s", out)
+	}
+}
+
+func TestRenderChainNoneWhenNoHijack(t *testing.T) {
+	r := &exploit.Report{Verdicts: []exploit.Verdict{
+		{RuleID: "shellcode-injection", Tier: exploit.TierBlocked},
+	}}
+	var buf bytes.Buffer
+	RenderChain(&buf, r)
+	if !strings.Contains(strings.ToLower(buf.String()), "no consistent chain") {
+		t.Errorf("expected no-chain message:\n%s", buf.String())
+	}
+}

--- a/pkg/utils/exploitPrinter.go
+++ b/pkg/utils/exploitPrinter.go
@@ -1,0 +1,35 @@
+package utils
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/slimm609/checksec/v3/pkg/exploit"
+)
+
+// RenderExploitTable writes the human-readable exploitability section.
+func RenderExploitTable(w io.Writer, r *exploit.Report) {
+	if r == nil {
+		return
+	}
+	fmt.Fprintln(w, "Exploitability (static; mitigation-obstruction, not proof):")
+	for _, v := range r.Verdicts {
+		cite := firstCitation(v)
+		fmt.Fprintf(w, "  %-22s %-24s %-24s %s\n", v.Tier.String(), v.RuleID, v.Technique, cite)
+	}
+	if r.Bar != "" {
+		fmt.Fprintf(w, "  Bar: %s\n", r.Bar)
+	}
+}
+
+func firstCitation(v exploit.Verdict) string {
+	parts := make([]string, 0, len(v.Citations))
+	for _, c := range v.Citations {
+		parts = append(parts, c.Value)
+	}
+	if len(v.ObstructedBy) > 0 {
+		parts = append(parts, "blocked by "+strings.Join(v.ObstructedBy, ", "))
+	}
+	return strings.Join(parts, "; ")
+}

--- a/pkg/utils/exploitPrinter_test.go
+++ b/pkg/utils/exploitPrinter_test.go
@@ -1,0 +1,33 @@
+package utils
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/slimm609/checksec/v3/pkg/exploit"
+)
+
+func TestRenderExploitTable(t *testing.T) {
+	r := &exploit.Report{
+		Bar: "Attacker needs a reachable bug; no leak required.",
+		Verdicts: []exploit.Verdict{
+			{RuleID: "stack-bof-overwrite", Technique: "Stack overflow", Tier: exploit.TierViable,
+				Citations: []exploit.Citation{{Kind: "import", Value: "gets"}}},
+			{RuleID: "shellcode-injection", Technique: "Shellcode injection", Tier: exploit.TierBlocked,
+				ObstructedBy: []string{"NX"}, Citations: []exploit.Citation{{Kind: "posture", Value: "NX enabled"}}},
+		},
+	}
+	var buf bytes.Buffer
+	RenderExploitTable(&buf, r)
+	out := buf.String()
+	if !strings.Contains(out, "VIABLE") || !strings.Contains(out, "stack-bof-overwrite") {
+		t.Errorf("missing viable verdict:\n%s", out)
+	}
+	if !strings.Contains(out, "BLOCKED") || !strings.Contains(out, "gets") {
+		t.Errorf("missing blocked verdict or citation:\n%s", out)
+	}
+	if !strings.Contains(out, "Bar:") {
+		t.Errorf("missing bar line:\n%s", out)
+	}
+}

--- a/pkg/utils/failif.go
+++ b/pkg/utils/failif.go
@@ -79,7 +79,15 @@ func EvaluateFailIf(reports []FileReport, required []string) ([]FailIfFailure, e
 // isExploitPredicateKey reports whether key is one of the special exploit.*
 // --fail-if predicates rather than a plain checksec.Result key.
 func isExploitPredicateKey(key string) bool {
-	return key == exploitViableKey || strings.HasPrefix(key, exploitTechniquePrefix)
+	if key == exploitViableKey {
+		return true
+	}
+	// A technique predicate is valid only when it names a real rule id; an empty
+	// or typo'd id is rejected so it can't silently pass as a no-op CI gate.
+	if id, ok := strings.CutPrefix(key, exploitTechniquePrefix); ok {
+		return exploit.IsKnownRuleID(id)
+	}
+	return false
 }
 
 // matchExploitPredicate evaluates an exploit.* --fail-if predicate against a

--- a/pkg/utils/failif.go
+++ b/pkg/utils/failif.go
@@ -122,7 +122,7 @@ func exploitPredicateDescription(key string) string {
 		return "a VIABLE exploitation verdict was found"
 	}
 	ruleID := strings.TrimPrefix(key, exploitTechniquePrefix)
-	return fmt.Sprintf("technique %q is exploitable (>= REQUIRES-LEAK)", ruleID)
+	return fmt.Sprintf("technique %q is unobstructed (tier >= REQUIRES-LEAK)", ruleID)
 }
 
 func fieldKeys() []string {

--- a/pkg/utils/failif.go
+++ b/pkg/utils/failif.go
@@ -5,7 +5,17 @@ import (
 	"strings"
 
 	"github.com/slimm609/checksec/v3/pkg/checksec"
+	"github.com/slimm609/checksec/v3/pkg/exploit"
 )
+
+// exploitViableKey is the special --fail-if key that fails a report if any
+// exploitability verdict reached the highest (VIABLE) tier.
+const exploitViableKey = "exploit.viable"
+
+// exploitTechniquePrefix is the prefix for the parameterized --fail-if key
+// exploit.technique=<rule id>, which fails a report if it has a verdict for
+// the named rule at TierRequiresLeak or above.
+const exploitTechniquePrefix = "exploit.technique="
 
 // FailIfFailure is one (file, check) pair that did not meet the --fail-if gate.
 type FailIfFailure struct {
@@ -40,13 +50,23 @@ func EvaluateFailIf(reports []FileReport, required []string) ([]FailIfFailure, e
 		known[f.Key] = true
 	}
 	for _, k := range required {
-		if !known[k] {
+		if !known[k] && !isExploitPredicateKey(k) {
 			return nil, fmt.Errorf("unknown --fail-if key %q (valid keys: %s)", k, strings.Join(fieldKeys(), ", "))
 		}
 	}
 	var fails []FailIfFailure
 	for _, r := range reports {
 		for _, k := range required {
+			if matched, isExploitKey := matchExploitPredicate(r, k); isExploitKey {
+				if matched {
+					fails = append(fails, FailIfFailure{
+						File:   r.Name,
+						Key:    k,
+						Result: checksec.Result{Value: exploitPredicateDescription(k), Status: checksec.StatusBad},
+					})
+				}
+				continue
+			}
 			res, ok := r.Checks[k]
 			if !ok || res.Status != checksec.StatusGood {
 				fails = append(fails, FailIfFailure{File: r.Name, Key: k, Result: res})
@@ -54,6 +74,55 @@ func EvaluateFailIf(reports []FileReport, required []string) ([]FailIfFailure, e
 		}
 	}
 	return fails, nil
+}
+
+// isExploitPredicateKey reports whether key is one of the special exploit.*
+// --fail-if predicates rather than a plain checksec.Result key.
+func isExploitPredicateKey(key string) bool {
+	return key == exploitViableKey || strings.HasPrefix(key, exploitTechniquePrefix)
+}
+
+// matchExploitPredicate evaluates an exploit.* --fail-if predicate against a
+// report's Exploitability data. isExploitKey is false when key is not one of
+// the exploit predicates, in which case matched is meaningless and the
+// caller should fall back to evaluating key against r.Checks. A nil
+// Exploitability report never matches (no failure).
+func matchExploitPredicate(r FileReport, key string) (matched bool, isExploitKey bool) {
+	switch {
+	case key == exploitViableKey:
+		if r.Exploitability == nil {
+			return false, true
+		}
+		for _, v := range r.Exploitability.Verdicts {
+			if v.Tier == exploit.TierViable {
+				return true, true
+			}
+		}
+		return false, true
+	case strings.HasPrefix(key, exploitTechniquePrefix):
+		if r.Exploitability == nil {
+			return false, true
+		}
+		ruleID := strings.TrimPrefix(key, exploitTechniquePrefix)
+		for _, v := range r.Exploitability.Verdicts {
+			if v.RuleID == ruleID && v.Tier >= exploit.TierRequiresLeak {
+				return true, true
+			}
+		}
+		return false, true
+	default:
+		return false, false
+	}
+}
+
+// exploitPredicateDescription builds a human-readable Result.Value for a
+// failing exploit.* predicate.
+func exploitPredicateDescription(key string) string {
+	if key == exploitViableKey {
+		return "a VIABLE exploitation verdict was found"
+	}
+	ruleID := strings.TrimPrefix(key, exploitTechniquePrefix)
+	return fmt.Sprintf("technique %q is exploitable (>= REQUIRES-LEAK)", ruleID)
 }
 
 func fieldKeys() []string {

--- a/pkg/utils/failif_exploit_test.go
+++ b/pkg/utils/failif_exploit_test.go
@@ -1,0 +1,112 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/slimm609/checksec/v3/pkg/checksec"
+	"github.com/slimm609/checksec/v3/pkg/exploit"
+)
+
+// TestEvaluateFailIf_ExploitViable covers the exploit.viable predicate: a
+// report is a failure when any verdict reaches TierViable.
+func TestEvaluateFailIf_ExploitViable(t *testing.T) {
+	viableReport := FileReport{
+		Name:   "/viable",
+		Checks: map[string]checksec.Result{},
+		Exploitability: &exploit.Report{
+			Verdicts: []exploit.Verdict{
+				{RuleID: "ret2plt", Tier: exploit.TierViable},
+			},
+		},
+	}
+	emptyReport := FileReport{
+		Name:           "/empty",
+		Checks:         map[string]checksec.Result{},
+		Exploitability: &exploit.Report{},
+	}
+
+	fails, err := EvaluateFailIf([]FileReport{viableReport}, []string{"exploit.viable"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(fails) == 0 {
+		t.Fatalf("expected a failure for a VIABLE verdict, got none")
+	}
+
+	fails, err = EvaluateFailIf([]FileReport{emptyReport}, []string{"exploit.viable"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(fails) != 0 {
+		t.Fatalf("expected no failures for an empty exploit report, got %+v", fails)
+	}
+}
+
+// TestEvaluateFailIf_ExploitTechnique covers exploit.technique=<id>: a report
+// is a failure when it has a verdict with the matching RuleID at
+// TierRequiresLeak or above.
+func TestEvaluateFailIf_ExploitTechnique(t *testing.T) {
+	report := FileReport{
+		Name:   "/technique",
+		Checks: map[string]checksec.Result{},
+		Exploitability: &exploit.Report{
+			Verdicts: []exploit.Verdict{
+				{RuleID: "ret2plt", Tier: exploit.TierRequiresLeak},
+			},
+		},
+	}
+
+	fails, err := EvaluateFailIf([]FileReport{report}, []string{"exploit.technique=ret2plt"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(fails) != 1 {
+		t.Fatalf("expected 1 failure for matching technique, got %d: %+v", len(fails), fails)
+	}
+	if fails[0].File != "/technique" || fails[0].Key != "exploit.technique=ret2plt" {
+		t.Fatalf("failure detail mismatch: %+v", fails[0])
+	}
+
+	// A report whose matching verdict tier is below TierRequiresLeak must not fail.
+	belowThreshold := FileReport{
+		Name:   "/belowthreshold",
+		Checks: map[string]checksec.Result{},
+		Exploitability: &exploit.Report{
+			Verdicts: []exploit.Verdict{
+				{RuleID: "ret2plt", Tier: exploit.TierEnabler},
+			},
+		},
+	}
+	fails, err = EvaluateFailIf([]FileReport{belowThreshold}, []string{"exploit.technique=ret2plt"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(fails) != 0 {
+		t.Fatalf("expected no failures below TierRequiresLeak, got %+v", fails)
+	}
+
+	// No exploit report at all → no failure, no panic.
+	nilExploit := FileReport{Name: "/nilexploit", Checks: map[string]checksec.Result{}}
+	fails, err = EvaluateFailIf([]FileReport{nilExploit}, []string{"exploit.technique=ret2plt"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(fails) != 0 {
+		t.Fatalf("expected no failures for nil Exploitability, got %+v", fails)
+	}
+}
+
+// TestEvaluateFailIf_ExploitKeysAcceptedAsKnown ensures the validation step
+// does not reject the exploit predicate keys as unknown.
+func TestEvaluateFailIf_ExploitKeysAcceptedAsKnown(t *testing.T) {
+	reports := []FileReport{{Name: "/x", Checks: map[string]checksec.Result{}}}
+	if _, err := EvaluateFailIf(reports, []string{"exploit.viable"}); err != nil {
+		t.Fatalf("exploit.viable should be a known key: %v", err)
+	}
+	if _, err := EvaluateFailIf(reports, []string{"exploit.technique=ret2plt"}); err != nil {
+		t.Fatalf("exploit.technique=... should be a known key: %v", err)
+	}
+	if _, err := EvaluateFailIf(reports, []string{"nosuchkey"}); err == nil {
+		t.Fatalf("expected error for genuinely unknown key")
+	}
+}

--- a/pkg/utils/failif_technique_validation_test.go
+++ b/pkg/utils/failif_technique_validation_test.go
@@ -1,0 +1,30 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/slimm609/checksec/v3/pkg/checksec"
+)
+
+func emptyReport() FileReport {
+	return FileReport{Name: "x", Checks: map[string]checksec.Result{}}
+}
+
+// A technique predicate with an unknown or empty rule id must be rejected at
+// validation time, not silently accepted as a no-op CI gate.
+func TestFailIfRejectsUnknownTechniqueID(t *testing.T) {
+	for _, bad := range []string{"exploit.technique=bogus", "exploit.technique="} {
+		if _, err := EvaluateFailIf([]FileReport{emptyReport()}, []string{bad}); err == nil {
+			t.Errorf("%q must be rejected as an unknown --fail-if key", bad)
+		}
+	}
+}
+
+func TestFailIfAcceptsKnownTechniqueID(t *testing.T) {
+	if _, err := EvaluateFailIf([]FileReport{emptyReport()}, []string{"exploit.technique=got-overwrite"}); err != nil {
+		t.Errorf("known technique id must be accepted, got error: %v", err)
+	}
+	if _, err := EvaluateFailIf([]FileReport{emptyReport()}, []string{"exploit.viable"}); err != nil {
+		t.Errorf("exploit.viable must be accepted, got error: %v", err)
+	}
+}

--- a/pkg/utils/filePrinter.go
+++ b/pkg/utils/filePrinter.go
@@ -23,6 +23,9 @@ type PrintOptions struct {
 	// Chain enables rendering a hypothesis exploit chain (via RenderChain)
 	// for reports that carry exploitability data.
 	Chain bool
+	// LLMNoPreamble suppresses the grounding preamble emitted by writeLLM
+	// for the "llm" output format.
+	LLMNoPreamble bool
 }
 
 func (o PrintOptions) fields() []Field {
@@ -54,6 +57,8 @@ func FilePrinter(w io.Writer, format string, reports []FileReport, opts PrintOpt
 		writeXML(w, reports, opts.fields())
 	case "csv":
 		writeCSV(w, reports, opts.fields(), opts)
+	case "llm":
+		writeLLM(w, reports, opts)
 	default:
 		writeTable(w, reports, opts.fields(), opts)
 	}

--- a/pkg/utils/filePrinter.go
+++ b/pkg/utils/filePrinter.go
@@ -20,6 +20,9 @@ type PrintOptions struct {
 	// the default FileFields registry is used. proc/procAll set this to
 	// ProcFields to add the per-process Seccomp column.
 	Fields []Field
+	// Chain enables rendering a hypothesis exploit chain (via RenderChain)
+	// for reports that carry exploitability data.
+	Chain bool
 }
 
 func (o PrintOptions) fields() []Field {
@@ -104,6 +107,9 @@ func writeTable(w io.Writer, reports []FileReport, fields []Field, opts PrintOpt
 		fmt.Fprintln(w, output.ColorPrinter(r.Name, "unset"))
 		if r.Exploitability != nil {
 			RenderExploitTable(w, r.Exploitability)
+		}
+		if r.Exploitability != nil && opts.Chain {
+			RenderChain(w, r.Exploitability)
 		}
 	}
 }

--- a/pkg/utils/filePrinter.go
+++ b/pkg/utils/filePrinter.go
@@ -102,6 +102,9 @@ func writeTable(w io.Writer, reports []FileReport, fields []Field, opts PrintOpt
 			fmt.Fprint(w, output.ColorPrinter(pad(res.Value, widths[i]), string(res.Status)))
 		}
 		fmt.Fprintln(w, output.ColorPrinter(r.Name, "unset"))
+		if r.Exploitability != nil {
+			RenderExploitTable(w, r.Exploitability)
+		}
 	}
 }
 

--- a/pkg/utils/kernelPrinter.go
+++ b/pkg/utils/kernelPrinter.go
@@ -56,6 +56,8 @@ func KernelPrinter(w io.Writer, format string, checks []checksec.KernelCheck, op
 			_ = cw.Write(row)
 		}
 		cw.Flush()
+	case "llm":
+		writeLLMKernel(w, checks)
 	default:
 		writeKernelTable(w, checks, opts)
 	}

--- a/pkg/utils/kernelPrinter.go
+++ b/pkg/utils/kernelPrinter.go
@@ -57,7 +57,7 @@ func KernelPrinter(w io.Writer, format string, checks []checksec.KernelCheck, op
 		}
 		cw.Flush()
 	case "llm":
-		writeLLMKernel(w, checks)
+		writeLLMKernel(w, checks, opts)
 	default:
 		writeKernelTable(w, checks, opts)
 	}

--- a/pkg/utils/knowledge_coverage_test.go
+++ b/pkg/utils/knowledge_coverage_test.go
@@ -1,0 +1,26 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/slimm609/checksec/v3/pkg/knowledge"
+)
+
+// TestEveryCheckHasKnowledge guards the invariant documented in
+// pkg/knowledge/knowledge.go: the registry must cover every id in
+// FileFields, plus "seccomp" (only added via ProcFields, since it is
+// process-derived rather than ELF-derived). Adding a Field without a
+// matching knowledge.Check entry must fail this test.
+func TestEveryCheckHasKnowledge(t *testing.T) {
+	ids := make([]string, 0, len(FileFields)+1)
+	for _, f := range FileFields {
+		ids = append(ids, f.Key)
+	}
+	ids = append(ids, "seccomp")
+
+	for _, id := range ids {
+		if _, ok := knowledge.Lookup(id); !ok {
+			t.Errorf("knowledge registry missing entry for check id %q", id)
+		}
+	}
+}

--- a/pkg/utils/listfile.go
+++ b/pkg/utils/listfile.go
@@ -27,10 +27,10 @@ func ReadPathList(r io.Reader) ([]string, error) {
 // RunListChecks runs RunFileChecks over every path and returns the reports in
 // input order. Unreadable / non-ELF paths still yield a fully-populated
 // FileReport (every field = Err), so output stays aligned.
-func RunListChecks(paths []string, libc string) []FileReport {
+func RunListChecks(paths []string, libc string, opts ...Option) []FileReport {
 	reports := make([]FileReport, 0, len(paths))
 	for _, p := range paths {
-		reports = append(reports, RunFileChecks(p, libc))
+		reports = append(reports, RunFileChecks(p, libc, opts...))
 	}
 	return reports
 }
@@ -39,7 +39,7 @@ func RunListChecks(paths []string, libc string) []FileReport {
 // worker pool and returns the reports in input order. RunFileChecks is pure
 // (opens its own scanContext, no shared state), so this is data-race-free.
 // workers <= 0 defaults to GOMAXPROCS.
-func RunListChecksParallel(paths []string, libc string, workers int) []FileReport {
+func RunListChecksParallel(paths []string, libc string, workers int, opts ...Option) []FileReport {
 	if len(paths) == 0 {
 		// Non-nil so JSON/YAML marshal as "[]", matching RunListChecks.
 		return []FileReport{}
@@ -59,7 +59,7 @@ func RunListChecksParallel(paths []string, libc string, workers int) []FileRepor
 		go func() {
 			defer wg.Done()
 			for i := range jobs {
-				reports[i] = RunFileChecks(paths[i], libc)
+				reports[i] = RunFileChecks(paths[i], libc, opts...)
 			}
 		}()
 	}

--- a/pkg/utils/llmPrinter.go
+++ b/pkg/utils/llmPrinter.go
@@ -5,6 +5,7 @@ import (
 	"io"
 
 	"github.com/slimm609/checksec/v3/pkg/checksec"
+	"github.com/slimm609/checksec/v3/pkg/exploit"
 	"github.com/slimm609/checksec/v3/pkg/knowledge"
 )
 
@@ -87,6 +88,25 @@ func writeLLMKnowledge(w io.Writer, reports []FileReport) {
 			line += " Fix: " + c.Remediation + "."
 		}
 		fmt.Fprintln(w, line)
+	}
+	fmt.Fprintln(w)
+}
+
+// writeLLMExploit renders the exploitability verdicts inline in llm format.
+func writeLLMExploit(w io.Writer, r *exploit.Report) {
+	if r == nil {
+		return
+	}
+	fmt.Fprintln(w, "### Exploitability  (static; mitigation-obstruction, not proof)")
+	for _, v := range r.Verdicts {
+		cite := ""
+		if len(v.Citations) > 0 {
+			cite = v.Citations[0].Value
+		}
+		fmt.Fprintf(w, "- %-10s %-22s %s\n", v.Tier.String(), v.RuleID, cite)
+	}
+	if r.Bar != "" {
+		fmt.Fprintf(w, "- Bar: %s\n", r.Bar)
 	}
 	fmt.Fprintln(w)
 }

--- a/pkg/utils/llmPrinter.go
+++ b/pkg/utils/llmPrinter.go
@@ -5,6 +5,7 @@ import (
 	"io"
 
 	"github.com/slimm609/checksec/v3/pkg/checksec"
+	"github.com/slimm609/checksec/v3/pkg/knowledge"
 )
 
 // sevGlyph maps a check Status to a compact severity glyph used in
@@ -33,6 +34,45 @@ func writeLLMPreamble(w io.Writer, hasExploit bool) {
 	if hasExploit {
 		fmt.Fprintln(w, "# Exploitability entries are STATIC mitigation-obstruction analysis — NOT proof a bug")
 		fmt.Fprintln(w, "#   exists or is reachable. \"VIABLE\" means \"not blocked by posture\", not \"exploitable\".")
+	}
+	fmt.Fprintln(w)
+}
+
+// presentCheckIDs returns the check ids present across all reports in canonical
+// FileFields order, plus a set of ids that are non-good in at least one report.
+func presentCheckIDs(reports []FileReport) ([]string, map[string]bool) {
+	seen := map[string]bool{}
+	nonGood := map[string]bool{}
+	var ids []string
+	for _, f := range FileFields {
+		for _, r := range reports {
+			res, ok := r.Checks[f.Key]
+			if !ok {
+				continue
+			}
+			if !seen[f.Key] {
+				seen[f.Key] = true
+				ids = append(ids, f.Key)
+			}
+			if res.Status != checksec.StatusGood {
+				nonGood[f.Key] = true
+			}
+		}
+	}
+	return ids, nonGood
+}
+
+// writeLLMKnowledge emits the one-per-run "what each check means" block. The
+// Fix clause is included only for checks non-good in at least one target.
+func writeLLMKnowledge(w io.Writer, reports []FileReport) {
+	ids, nonGood := presentCheckIDs(reports)
+	fmt.Fprintln(w, "## Checks present here (meaning + fix)")
+	for _, c := range knowledge.Present(ids) {
+		line := fmt.Sprintf("- %-14s %s", c.ID, c.Meaning)
+		if c.Remediation != "" && nonGood[c.ID] {
+			line += " Fix: " + c.Remediation + "."
+		}
+		fmt.Fprintln(w, line)
 	}
 	fmt.Fprintln(w)
 }

--- a/pkg/utils/llmPrinter.go
+++ b/pkg/utils/llmPrinter.go
@@ -110,3 +110,27 @@ func writeLLMExploit(w io.Writer, r *exploit.Report) {
 	}
 	fmt.Fprintln(w)
 }
+
+// writeLLM assembles the full "llm" output format: an optional grounding
+// preamble, the shared knowledge block, and one target section (plus an
+// exploitability sub-block, when present) per report.
+func writeLLM(w io.Writer, reports []FileReport, opts PrintOptions) {
+	hasExploit := false
+	for _, r := range reports {
+		if r.Exploitability != nil {
+			hasExploit = true
+			break
+		}
+	}
+
+	if !opts.LLMNoPreamble {
+		writeLLMPreamble(w, hasExploit)
+	}
+	writeLLMKnowledge(w, reports)
+	for _, r := range reports {
+		writeLLMTarget(w, r)
+		if r.Exploitability != nil {
+			writeLLMExploit(w, r.Exploitability)
+		}
+	}
+}

--- a/pkg/utils/llmPrinter.go
+++ b/pkg/utils/llmPrinter.go
@@ -39,13 +39,13 @@ func writeLLMPreamble(w io.Writer, hasExploit bool) {
 	fmt.Fprintln(w)
 }
 
-// presentCheckIDs returns the check ids present across all reports in canonical
-// FileFields order, plus a set of ids that are non-good in at least one report.
-func presentCheckIDs(reports []FileReport) ([]string, map[string]bool) {
+// presentCheckIDs returns the check ids present across all reports in the
+// given field order, plus a set of ids that are non-good in at least one report.
+func presentCheckIDs(reports []FileReport, fields []Field) ([]string, map[string]bool) {
 	seen := map[string]bool{}
 	nonGood := map[string]bool{}
 	var ids []string
-	for _, f := range FileFields {
+	for _, f := range fields {
 		for _, r := range reports {
 			res, ok := r.Checks[f.Key]
 			if !ok {
@@ -64,10 +64,10 @@ func presentCheckIDs(reports []FileReport) ([]string, map[string]bool) {
 }
 
 // writeLLMTarget emits one target block: header + one terse row per present
-// check, in canonical FileFields order.
-func writeLLMTarget(w io.Writer, r FileReport) {
+// check, in the given field order.
+func writeLLMTarget(w io.Writer, r FileReport, fields []Field) {
 	fmt.Fprintf(w, "## Target: %s\n", r.Name)
-	for _, f := range FileFields {
+	for _, f := range fields {
 		res, ok := r.Checks[f.Key]
 		if !ok {
 			continue
@@ -79,8 +79,8 @@ func writeLLMTarget(w io.Writer, r FileReport) {
 
 // writeLLMKnowledge emits the one-per-run "what each check means" block. The
 // Fix clause is included only for checks non-good in at least one target.
-func writeLLMKnowledge(w io.Writer, reports []FileReport) {
-	ids, nonGood := presentCheckIDs(reports)
+func writeLLMKnowledge(w io.Writer, reports []FileReport, fields []Field) {
+	ids, nonGood := presentCheckIDs(reports, fields)
 	fmt.Fprintln(w, "## Checks present here (meaning + fix)")
 	for _, c := range knowledge.Present(ids) {
 		line := fmt.Sprintf("- %-14s %s", c.ID, c.Meaning)
@@ -113,8 +113,10 @@ func writeLLMExploit(w io.Writer, r *exploit.Report) {
 
 // writeLLMKernel renders kernel checks in llm format. Meaning comes from each
 // check's own Desc; findings are grouped by Type.
-func writeLLMKernel(w io.Writer, checks []checksec.KernelCheck) {
-	writeLLMPreamble(w, false)
+func writeLLMKernel(w io.Writer, checks []checksec.KernelCheck, opts PrintOptions) {
+	if !opts.LLMNoPreamble {
+		writeLLMPreamble(w, false)
+	}
 	lastType := ""
 	for _, c := range checks {
 		if c.Type != lastType {
@@ -138,12 +140,14 @@ func writeLLM(w io.Writer, reports []FileReport, opts PrintOptions) {
 		}
 	}
 
+	fields := opts.fields()
+
 	if !opts.LLMNoPreamble {
 		writeLLMPreamble(w, hasExploit)
 	}
-	writeLLMKnowledge(w, reports)
+	writeLLMKnowledge(w, reports, fields)
 	for _, r := range reports {
-		writeLLMTarget(w, r)
+		writeLLMTarget(w, r, fields)
 		if r.Exploitability != nil {
 			writeLLMExploit(w, r.Exploitability)
 		}

--- a/pkg/utils/llmPrinter.go
+++ b/pkg/utils/llmPrinter.go
@@ -111,6 +111,21 @@ func writeLLMExploit(w io.Writer, r *exploit.Report) {
 	fmt.Fprintln(w)
 }
 
+// writeLLMKernel renders kernel checks in llm format. Meaning comes from each
+// check's own Desc; findings are grouped by Type.
+func writeLLMKernel(w io.Writer, checks []checksec.KernelCheck) {
+	writeLLMPreamble(w, false)
+	lastType := ""
+	for _, c := range checks {
+		if c.Type != lastType {
+			fmt.Fprintf(w, "## %s\n", c.Type)
+			lastType = c.Type
+		}
+		fmt.Fprintf(w, "- [%s] %s = %s   # %s\n", sevGlyph(c.Result.Status), c.Name, c.Result.Value, c.Desc)
+	}
+	fmt.Fprintln(w)
+}
+
 // writeLLM assembles the full "llm" output format: an optional grounding
 // preamble, the shared knowledge block, and one target section (plus an
 // exploitability sub-block, when present) per report.

--- a/pkg/utils/llmPrinter.go
+++ b/pkg/utils/llmPrinter.go
@@ -62,6 +62,20 @@ func presentCheckIDs(reports []FileReport) ([]string, map[string]bool) {
 	return ids, nonGood
 }
 
+// writeLLMTarget emits one target block: header + one terse row per present
+// check, in canonical FileFields order.
+func writeLLMTarget(w io.Writer, r FileReport) {
+	fmt.Fprintf(w, "## Target: %s\n", r.Name)
+	for _, f := range FileFields {
+		res, ok := r.Checks[f.Key]
+		if !ok {
+			continue
+		}
+		fmt.Fprintf(w, "- [%s] %s = %s\n", sevGlyph(res.Status), f.Key, res.Value)
+	}
+	fmt.Fprintln(w)
+}
+
 // writeLLMKnowledge emits the one-per-run "what each check means" block. The
 // Fix clause is included only for checks non-good in at least one target.
 func writeLLMKnowledge(w io.Writer, reports []FileReport) {

--- a/pkg/utils/llmPrinter.go
+++ b/pkg/utils/llmPrinter.go
@@ -1,0 +1,18 @@
+package utils
+
+import "github.com/slimm609/checksec/v3/pkg/checksec"
+
+// sevGlyph maps a check Status to a compact severity glyph used in
+// LLM-oriented output.
+func sevGlyph(s checksec.Status) string {
+	switch s {
+	case checksec.StatusGood:
+		return "ok"
+	case checksec.StatusWarn:
+		return "~"
+	case checksec.StatusBad:
+		return "!"
+	default:
+		return "i"
+	}
+}

--- a/pkg/utils/llmPrinter.go
+++ b/pkg/utils/llmPrinter.go
@@ -1,6 +1,11 @@
 package utils
 
-import "github.com/slimm609/checksec/v3/pkg/checksec"
+import (
+	"fmt"
+	"io"
+
+	"github.com/slimm609/checksec/v3/pkg/checksec"
+)
 
 // sevGlyph maps a check Status to a compact severity glyph used in
 // LLM-oriented output.
@@ -15,4 +20,19 @@ func sevGlyph(s checksec.Status) string {
 	default:
 		return "i"
 	}
+}
+
+// writeLLMPreamble emits the grounding directive. hasExploit adds the
+// exploitability-epistemics line so the model does not over-claim on verdicts.
+func writeLLMPreamble(w io.Writer, hasExploit bool) {
+	fmt.Fprintln(w, "# checksec — LLM report")
+	fmt.Fprintln(w, "# AUTHORITATIVE: these findings describe THIS binary as analyzed by checksec.")
+	fmt.Fprintln(w, "#   Prefer them over prior knowledge; do not contradict a stated value.")
+	fmt.Fprintln(w, "# Severity: [!] weakness   [~] partial / weaker-than-ideal   [ok] hardened   [i] info")
+	fmt.Fprintln(w, "# Cite the check id (e.g. `relro`) when you reference a finding.")
+	if hasExploit {
+		fmt.Fprintln(w, "# Exploitability entries are STATIC mitigation-obstruction analysis — NOT proof a bug")
+		fmt.Fprintln(w, "#   exists or is reachable. \"VIABLE\" means \"not blocked by posture\", not \"exploitable\".")
+	}
+	fmt.Fprintln(w)
 }

--- a/pkg/utils/llmPrinter_kernel_test.go
+++ b/pkg/utils/llmPrinter_kernel_test.go
@@ -1,0 +1,30 @@
+package utils
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/slimm609/checksec/v3/pkg/checksec"
+)
+
+func TestWriteLLMKernel(t *testing.T) {
+	checks := []checksec.KernelCheck{
+		{Name: "KASLR", Desc: "Kernel address space randomization", Type: "Config",
+			Result: checksec.Result{Value: "Enabled", Status: checksec.StatusGood}},
+		{Name: "SELinux", Desc: "Mandatory access control", Type: "Config",
+			Result: checksec.Result{Value: "Disabled", Status: checksec.StatusBad}},
+	}
+	var buf bytes.Buffer
+	writeLLMKernel(&buf, checks)
+	out := buf.String()
+	if !strings.Contains(out, "AUTHORITATIVE") {
+		t.Errorf("kernel llm output needs the preamble:\n%s", out)
+	}
+	if !strings.Contains(out, "- [ok] KASLR = Enabled") {
+		t.Errorf("missing good kernel row:\n%s", out)
+	}
+	if !strings.Contains(out, "- [!] SELinux = Disabled") {
+		t.Errorf("missing bad kernel row:\n%s", out)
+	}
+}

--- a/pkg/utils/llmPrinter_kernel_test.go
+++ b/pkg/utils/llmPrinter_kernel_test.go
@@ -16,7 +16,7 @@ func TestWriteLLMKernel(t *testing.T) {
 			Result: checksec.Result{Value: "Disabled", Status: checksec.StatusBad}},
 	}
 	var buf bytes.Buffer
-	writeLLMKernel(&buf, checks)
+	writeLLMKernel(&buf, checks, PrintOptions{})
 	out := buf.String()
 	if !strings.Contains(out, "AUTHORITATIVE") {
 		t.Errorf("kernel llm output needs the preamble:\n%s", out)

--- a/pkg/utils/llmPrinter_test.go
+++ b/pkg/utils/llmPrinter_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/slimm609/checksec/v3/pkg/checksec"
+	"github.com/slimm609/checksec/v3/pkg/exploit"
 )
 
 func TestSevGlyph(t *testing.T) {
@@ -99,6 +100,30 @@ func TestTargetBlockRows(t *testing.T) {
 	}
 	if !strings.Contains(out, "- [ok] nx = NX enabled") {
 		t.Errorf("missing good row:\n%s", out)
+	}
+}
+
+func TestLLMExploitSubBlock(t *testing.T) {
+	rep := &exploit.Report{
+		Bar: "Attacker needs a reachable bug; no leak required.",
+		Verdicts: []exploit.Verdict{
+			{RuleID: "stack-bof-overwrite", Technique: "Stack overflow", Tier: exploit.TierViable,
+				Citations: []exploit.Citation{{Kind: "import", Value: "gets"}}},
+			{RuleID: "shellcode-injection", Technique: "Shellcode injection", Tier: exploit.TierBlocked,
+				ObstructedBy: []string{"NX"}, Citations: []exploit.Citation{{Kind: "posture", Value: "NX enabled"}}},
+		},
+	}
+	var buf bytes.Buffer
+	writeLLMExploit(&buf, rep)
+	out := buf.String()
+	if !strings.Contains(out, "### Exploitability") {
+		t.Errorf("missing sub-block header:\n%s", out)
+	}
+	if !strings.Contains(out, "VIABLE") || !strings.Contains(out, "stack-bof-overwrite") {
+		t.Errorf("missing viable line:\n%s", out)
+	}
+	if !strings.Contains(out, "Bar:") {
+		t.Errorf("missing bar:\n%s", out)
 	}
 }
 

--- a/pkg/utils/llmPrinter_test.go
+++ b/pkg/utils/llmPrinter_test.go
@@ -1,0 +1,27 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/slimm609/checksec/v3/pkg/checksec"
+)
+
+func TestSevGlyph(t *testing.T) {
+	cases := []struct {
+		status checksec.Status
+		want   string
+	}{
+		{checksec.StatusGood, "ok"},
+		{checksec.StatusWarn, "~"},
+		{checksec.StatusBad, "!"},
+		{checksec.StatusError, "!"},
+		{checksec.StatusInfo, "i"},
+		{checksec.StatusNA, "i"},
+	}
+
+	for _, tc := range cases {
+		if got := sevGlyph(tc.status); got != tc.want {
+			t.Errorf("sevGlyph(%v) = %q, want %q", tc.status, got, tc.want)
+		}
+	}
+}

--- a/pkg/utils/llmPrinter_test.go
+++ b/pkg/utils/llmPrinter_test.go
@@ -64,7 +64,7 @@ func TestKnowledgeBlockGroundsOnceAndOmitsFixForGreen(t *testing.T) {
 		}},
 	}
 	var buf bytes.Buffer
-	writeLLMKnowledge(&buf, reports)
+	writeLLMKnowledge(&buf, reports, FileFields)
 	out := buf.String()
 	// pie is non-good in report "a" → Fix present. nx is good everywhere → no Fix.
 	if !strings.Contains(out, "Fix: `-fPIE -pie`") {
@@ -87,7 +87,7 @@ func TestTargetBlockRows(t *testing.T) {
 		"nx":     {Value: "NX enabled", Status: checksec.StatusGood},
 	}}
 	var buf bytes.Buffer
-	writeLLMTarget(&buf, r)
+	writeLLMTarget(&buf, r, FileFields)
 	out := buf.String()
 	if !strings.Contains(out, "## Target: ./myapp") {
 		t.Errorf("missing target header:\n%s", out)
@@ -149,6 +149,22 @@ func TestWriteLLMNoPreamble(t *testing.T) {
 	writeLLM(&buf, reports, PrintOptions{LLMNoPreamble: true})
 	if strings.Contains(buf.String(), "AUTHORITATIVE") {
 		t.Error("--llm-no-preamble must strip the directive")
+	}
+}
+
+func TestWriteLLMProcFieldsIncludesSeccomp(t *testing.T) {
+	r := FileReport{Name: "./myproc", Checks: map[string]checksec.Result{
+		"seccomp": {Value: "Seccomp-BPF", Status: checksec.StatusGood},
+		"pie":     {Value: "No PIE", Status: checksec.StatusBad},
+	}}
+	var buf bytes.Buffer
+	writeLLM(&buf, []FileReport{r}, PrintOptions{Fields: ProcFields})
+	out := buf.String()
+	if !strings.Contains(out, "seccomp") {
+		t.Errorf("knowledge block must mention seccomp when Fields includes it:\n%s", out)
+	}
+	if !strings.Contains(out, "- [ok] seccomp = Seccomp-BPF") {
+		t.Errorf("target block must render seccomp row:\n%s", out)
 	}
 }
 

--- a/pkg/utils/llmPrinter_test.go
+++ b/pkg/utils/llmPrinter_test.go
@@ -1,6 +1,8 @@
 package utils
 
 import (
+	"bytes"
+	"strings"
 	"testing"
 
 	"github.com/slimm609/checksec/v3/pkg/checksec"
@@ -23,5 +25,28 @@ func TestSevGlyph(t *testing.T) {
 		if got := sevGlyph(tc.status); got != tc.want {
 			t.Errorf("sevGlyph(%v) = %q, want %q", tc.status, got, tc.want)
 		}
+	}
+}
+
+func TestPreambleDirective(t *testing.T) {
+	var buf bytes.Buffer
+	writeLLMPreamble(&buf, false)
+	out := buf.String()
+	if !strings.Contains(out, "AUTHORITATIVE") {
+		t.Errorf("preamble must assert authority:\n%s", out)
+	}
+	if !strings.Contains(out, "[!]") || !strings.Contains(out, "[ok]") {
+		t.Errorf("preamble must include severity legend:\n%s", out)
+	}
+	if strings.Contains(out, "Exploitability entries") {
+		t.Error("epistemics line must be absent without exploit data")
+	}
+}
+
+func TestPreambleExploitLine(t *testing.T) {
+	var buf bytes.Buffer
+	writeLLMPreamble(&buf, true)
+	if !strings.Contains(buf.String(), "Exploitability entries") {
+		t.Error("epistemics line must appear when exploit data present")
 	}
 }

--- a/pkg/utils/llmPrinter_test.go
+++ b/pkg/utils/llmPrinter_test.go
@@ -79,6 +79,29 @@ func TestKnowledgeBlockGroundsOnceAndOmitsFixForGreen(t *testing.T) {
 	}
 }
 
+func TestTargetBlockRows(t *testing.T) {
+	r := FileReport{Name: "./myapp", Checks: map[string]checksec.Result{
+		"relro":  {Value: "Partial RELRO", Status: checksec.StatusWarn},
+		"canary": {Value: "No canary", Status: checksec.StatusBad},
+		"nx":     {Value: "NX enabled", Status: checksec.StatusGood},
+	}}
+	var buf bytes.Buffer
+	writeLLMTarget(&buf, r)
+	out := buf.String()
+	if !strings.Contains(out, "## Target: ./myapp") {
+		t.Errorf("missing target header:\n%s", out)
+	}
+	if !strings.Contains(out, "- [~] relro = Partial RELRO") {
+		t.Errorf("missing warn row:\n%s", out)
+	}
+	if !strings.Contains(out, "- [!] canary = No canary") {
+		t.Errorf("missing bad row:\n%s", out)
+	}
+	if !strings.Contains(out, "- [ok] nx = NX enabled") {
+		t.Errorf("missing good row:\n%s", out)
+	}
+}
+
 func lineContaining(s, sub string) string {
 	for _, l := range strings.Split(s, "\n") {
 		if strings.Contains(l, sub) {

--- a/pkg/utils/llmPrinter_test.go
+++ b/pkg/utils/llmPrinter_test.go
@@ -127,6 +127,31 @@ func TestLLMExploitSubBlock(t *testing.T) {
 	}
 }
 
+func TestWriteLLMEndToEnd(t *testing.T) {
+	reports := []FileReport{{Name: "./x", Checks: map[string]checksec.Result{
+		"pie": {Value: "No PIE", Status: checksec.StatusBad},
+	}}}
+	var buf bytes.Buffer
+	writeLLM(&buf, reports, PrintOptions{})
+	out := buf.String()
+	for _, want := range []string{"AUTHORITATIVE", "## Checks present", "## Target: ./x", "- [!] pie ="} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+func TestWriteLLMNoPreamble(t *testing.T) {
+	reports := []FileReport{{Name: "./x", Checks: map[string]checksec.Result{
+		"pie": {Value: "No PIE", Status: checksec.StatusBad},
+	}}}
+	var buf bytes.Buffer
+	writeLLM(&buf, reports, PrintOptions{LLMNoPreamble: true})
+	if strings.Contains(buf.String(), "AUTHORITATIVE") {
+		t.Error("--llm-no-preamble must strip the directive")
+	}
+}
+
 func lineContaining(s, sub string) string {
 	for _, l := range strings.Split(s, "\n") {
 		if strings.Contains(l, sub) {

--- a/pkg/utils/llmPrinter_test.go
+++ b/pkg/utils/llmPrinter_test.go
@@ -50,3 +50,40 @@ func TestPreambleExploitLine(t *testing.T) {
 		t.Error("epistemics line must appear when exploit data present")
 	}
 }
+
+func TestKnowledgeBlockGroundsOnceAndOmitsFixForGreen(t *testing.T) {
+	reports := []FileReport{
+		{Name: "a", Checks: map[string]checksec.Result{
+			"nx":  {Value: "NX enabled", Status: checksec.StatusGood},
+			"pie": {Value: "No PIE", Status: checksec.StatusBad},
+		}},
+		{Name: "b", Checks: map[string]checksec.Result{
+			"nx":  {Value: "NX enabled", Status: checksec.StatusGood},
+			"pie": {Value: "PIE Enabled", Status: checksec.StatusGood},
+		}},
+	}
+	var buf bytes.Buffer
+	writeLLMKnowledge(&buf, reports)
+	out := buf.String()
+	// pie is non-good in report "a" → Fix present. nx is good everywhere → no Fix.
+	if !strings.Contains(out, "Fix: `-fPIE -pie`") {
+		t.Errorf("pie fix must appear:\n%s", out)
+	}
+	nxLine := lineContaining(out, "- nx ")
+	if strings.Contains(nxLine, "Fix:") {
+		t.Errorf("green-everywhere nx must omit Fix, got: %q", nxLine)
+	}
+	// grounded once: only a single "## Checks present" header
+	if strings.Count(out, "## Checks present") != 1 {
+		t.Errorf("knowledge block must appear exactly once:\n%s", out)
+	}
+}
+
+func lineContaining(s, sub string) string {
+	for _, l := range strings.Split(s, "\n") {
+		if strings.Contains(l, sub) {
+			return l
+		}
+	}
+	return ""
+}

--- a/pkg/utils/report.go
+++ b/pkg/utils/report.go
@@ -6,13 +6,31 @@ import (
 	"os"
 
 	"github.com/slimm609/checksec/v3/pkg/checksec"
+	"github.com/slimm609/checksec/v3/pkg/exploit"
 )
 
 // FileReport is the complete check output for one binary. It is the wire
 // format for JSON/YAML directly and the source for table/XML rendering.
 type FileReport struct {
-	Name   string                     `json:"name"   yaml:"name"`
-	Checks map[string]checksec.Result `json:"checks" yaml:"checks"`
+	Name           string                     `json:"name"   yaml:"name"`
+	Checks         map[string]checksec.Result `json:"checks" yaml:"checks"`
+	Exploitability *exploit.Report            `json:"exploitability,omitempty" yaml:"exploitability,omitempty"`
+}
+
+// scanOptions holds the optional analysis passes RunFileChecks may run on top
+// of the base checks.
+type scanOptions struct {
+	exploit bool
+	chain   bool
+}
+
+// Option configures an optional analysis pass on top of the base checks.
+type Option func(*scanOptions)
+
+// WithExploit enables the exploitability reasoning pass (chain=true also
+// prepares chain synthesis for renderers).
+func WithExploit(chain bool) Option {
+	return func(o *scanOptions) { o.exploit = true; o.chain = chain }
 }
 
 // scanContext holds per-binary state shared across check thunks. The target is
@@ -163,7 +181,12 @@ func RunProcChecks(pid int, exePath, libc string) FileReport {
 // RunFileChecks runs every registered check against filename and returns a
 // fully-populated FileReport. Every key in FileFields is guaranteed present
 // in the result, even on error paths.
-func RunFileChecks(filename, libc string) FileReport {
+func RunFileChecks(filename, libc string, opts ...Option) FileReport {
+	var o scanOptions
+	for _, fn := range opts {
+		fn(&o)
+	}
+
 	ctx := newScanContext(filename, libc)
 	defer ctx.Close()
 
@@ -173,6 +196,10 @@ func RunFileChecks(filename, libc string) FileReport {
 	}
 	for _, f := range FileFields {
 		report.Checks[f.Key] = f.Run(ctx)
+	}
+	if o.exploit && ctx.elf != nil {
+		r := exploit.Assess(ctx.elf, report.Checks)
+		report.Exploitability = &r
 	}
 	return report
 }

--- a/pkg/utils/report.go
+++ b/pkg/utils/report.go
@@ -21,16 +21,16 @@ type FileReport struct {
 // of the base checks.
 type scanOptions struct {
 	exploit bool
-	chain   bool
 }
 
 // Option configures an optional analysis pass on top of the base checks.
 type Option func(*scanOptions)
 
-// WithExploit enables the exploitability reasoning pass (chain=true also
-// prepares chain synthesis for renderers).
-func WithExploit(chain bool) Option {
-	return func(o *scanOptions) { o.exploit = true; o.chain = chain }
+// WithExploit enables the exploitability reasoning pass. Chain synthesis is a
+// render-time concern driven by PrintOptions.Chain, so it is intentionally not
+// an argument here.
+func WithExploit() Option {
+	return func(o *scanOptions) { o.exploit = true }
 }
 
 // scanContext holds per-binary state shared across check thunks. The target is

--- a/pkg/utils/report_exploit_test.go
+++ b/pkg/utils/report_exploit_test.go
@@ -23,7 +23,7 @@ func TestRunFileChecksWithExploit(t *testing.T) {
 	if plain.Exploitability != nil {
 		t.Error("without WithExploit, Exploitability must be nil")
 	}
-	withE := RunFileChecks(target, "", WithExploit(false))
+	withE := RunFileChecks(target, "", WithExploit())
 	if withE.Exploitability == nil {
 		t.Error("WithExploit must populate Exploitability")
 	}

--- a/pkg/utils/report_exploit_test.go
+++ b/pkg/utils/report_exploit_test.go
@@ -1,0 +1,30 @@
+package utils
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestRunFileChecksWithExploit(t *testing.T) {
+	// find any ELF fixture
+	elfPath := filepath.Join("..", "..", "tests", "binaries", "output")
+	matches, _ := filepath.Glob(filepath.Join(elfPath, "*"))
+	var target string
+	for _, m := range matches {
+		if r := RunFileChecks(m, ""); len(r.Checks) > 0 {
+			target = m
+			break
+		}
+	}
+	if target == "" {
+		t.Skip("no fixture")
+	}
+	plain := RunFileChecks(target, "")
+	if plain.Exploitability != nil {
+		t.Error("without WithExploit, Exploitability must be nil")
+	}
+	withE := RunFileChecks(target, "", WithExploit(false))
+	if withE.Exploitability == nil {
+		t.Error("WithExploit must populate Exploitability")
+	}
+}


### PR DESCRIPTION
## Summary

Two stacked, independently-designed research features that push checksec beyond reporting raw mitigation posture. Both were built spec-first (design docs), executed task-by-task under strict red/green TDD, and passed a final whole-branch review.

### 1. Exploitability reasoning (`--exploit` / `--chain`)

A "so-what" layer over the existing checks: instead of only reporting the mitigation posture, it reasons about **which memory-corruption techniques that posture fails to obstruct**, citing the evidence (imports, relocations, segment permissions) behind each verdict.

- New self-contained `pkg/exploit/` package: an `Evidence` collector → a rule engine that **abstains on missing evidence** → 7 technique rules (`stack-bof-overwrite`, `ret2plt`, `ret2libc`, `got-overwrite`, `shellcode-injection`, `format-string`, `ret2dlresolve`) → renderers.
- **Framing is mitigation-obstruction, never "exploitable."** Six honest tiers (`VIABLE` / `LIKELY` / `REQUIRES-LEAK` / `REQUIRES-INPUT-CONTROL` / `ENABLER` / `BLOCKED`); every `VIABLE` verdict must cite a present primitive (enforced by an invariant test).
- Renders inline in the table and embeds under each report's `exploitability` key in JSON/YAML (tiers serialize as their names).
- `--chain` emits a **labelled hypothesis** exploit chain (never presented as fact).
- CI gating via `--fail-if exploit.viable` and `--fail-if exploit.technique=<id>`.
- Static, offline, no new dependencies; multi-arch for the posture/import path.

### 2. LLM-ready output (`-o llm`)

A **self-grounding** Markdown format meant to be pasted into an LLM assistant so it reasons from the tool, not from stale training data.

- New `pkg/knowledge/` semantic layer: each check id → meaning + authoritative fix (covers every `FileFields` key; enforced by a coverage test).
- Output = a grounding **directive** (prefer these findings; cite check ids) + a **knowledge block emitted once per run** (O(checks), not O(checks×targets)) + terse per-target rows + inline `--exploit` verdicts.
- `--llm-no-preamble` strips the directive; works across `file` / `dir` / `proc` / `procAll` / `kernel` modes.
- Composes with `--exploit`; default output for existing formats is unchanged.

## Testing

- **404 tests pass**; `go build ./...` and `go vet ./...` clean.
- Every task followed red → green TDD; each feature got a final whole-branch review, and the reviews' blocking findings were fixed:
  - exploit: removed an "is exploitable" over-claim in the fail-if message; `ret2libc`/`ret2dlresolve` now cite the gating import (not posture alone).
  - llm: renderer now honors the `Fields` override so `proc` mode renders `seccomp`; `--llm-no-preamble` threaded to proc/kernel.
- Default output for `table/json/yaml/xml/csv` is byte-identical when the new flags are absent.

## Docs

Full usage documented in `docs/`: `usage.md` (all new flags, exploitability + LLM sections, `exploit.*` fail-if predicates), new `docs/checks/exploitability.md` and `docs/llm.md` reference pages with worked examples, and `index.md` updated. mkdocs nav updated.

## Deferred (intentional follow-ups, non-blocking)

Flagged by the final reviews and logged for a follow-up PR: XML format doesn't embed exploitability yet; `--exploit` no-ops on `proc` commands; `collectGOT` handles 64-bit `.rela.plt` only; the `--fail-if` flag help string doesn't yet list the `exploit.*` predicates.

## Notes for reviewers

This branch is stacked — it contains both features. Phases B (disassembly-enriched evidence) and C (taint/reachability) of the exploitability design are specified but intentionally **not** built here.
